### PR TITLE
CommandHandler: Implement simple help command 

### DIFF
--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -25,7 +25,7 @@ export default class CommandHandler {
         }
 
         if (!this.production) {
-            message.reply(
+            await message.reply(
                 `Buggie bot recieved '${this.echoMessage(message)}' from ${message.author.tag}`
             );
         }

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -32,6 +32,13 @@ export default class CommandHandler {
 
         const commandParser = new CommandParser(message, this.prefix);
 
+        if (commandParser.parsedCommandName == "help") {
+            await message.reply(
+                "Available commands:\n" + this.commands.map(cmd => cmd.help(this.prefix)).join("\n")
+            );
+            return;
+        }
+
         const matchedCommand = this.commands.find(command =>
             command.commandNames.includes(commandParser.parsedCommandName)
         );


### PR DESCRIPTION
The help command has to be implemented in the command handler, as it holds the list of available commands

(This PR also includes a small commit that adds a missing await)