### PR TITLE
IssueCommand+PRCommand: Use emoji ID to correctly display custom emoji

### DIFF
--- a/src/commands/issueCommand.ts
+++ b/src/commands/issueCommand.ts
@@ -25,7 +25,7 @@ export class IssueCommand implements Command {
                 if (result) {
                     embed = this.embedFromIssue(parsedUserCommand, result);
                 } else {
-                    embed = "No matching issues found :sadcaret:";
+                    embed = "No matching issues found <:sadcaret:832714137166676018>";
                 }
 
                 await parsedUserCommand.send(embed);
@@ -39,7 +39,7 @@ export class IssueCommand implements Command {
             const embed = this.embedFromIssue(parsedUserCommand, result);
             await parsedUserCommand.send(embed);
         } else {
-            await parsedUserCommand.send(`No matching issues found :sadcaret:`);
+            await parsedUserCommand.send(`No matching issues found <:sadcaret:832714137166676018>`);
         }
     }
 

--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -30,7 +30,7 @@ export class PRCommand implements Command {
                 if (result) {
                     embed = this.embedFromPr(parsedUserCommand, result);
                 } else {
-                    embed = "No matching PRs found :sadcaret:";
+                    embed = "No matching PRs found <:sadcaret:832714137166676018>";
                 }
 
                 await parsedUserCommand.send(embed);
@@ -48,7 +48,9 @@ export class PRCommand implements Command {
             }
         }
 
-        await parsedUserCommand.send(`No matching pull requests found :sadcaret:`);
+        await parsedUserCommand.send(
+            `No matching pull requests found <:sadcaret:832714137166676018>`
+        );
     }
 
     private embedFromPr(


### PR DESCRIPTION
This fixes the issue of discord not preprocessing bots' messages for any custom emoji strings (ala :sadcaret:) and replacing them with the ID format. This commit uses the ID format explicitly to fix that.

In the future it might be beneficial to use the discordjs api somehow to not hardcode the emoji ID.