### PR TITLE
Utils: Add dynamic fetching of guild emojis

### DIFF
--- a/src/commands/issueCommand.ts
+++ b/src/commands/issueCommand.ts
@@ -3,7 +3,7 @@ import { RestEndpointMethodTypes } from "@octokit/rest";
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
 import githubAPI from "../apis/githubAPI";
-import { getEmoji } from "../util/emoji";
+import { getSadCaret } from "../util/emoji";
 
 export class IssueCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -26,7 +26,7 @@ export class IssueCommand implements Command {
                 if (result) {
                     embed = this.embedFromIssue(parsedUserCommand, result);
                 } else {
-                    const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+                    const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
                     embed = `No matching issues found ${sadcaret}`;
                 }
 
@@ -41,7 +41,7 @@ export class IssueCommand implements Command {
             const embed = this.embedFromIssue(parsedUserCommand, result);
             await parsedUserCommand.send(embed);
         } else {
-            const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+            const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
             await parsedUserCommand.send(`No matching issues found ${sadcaret}`);
         }
     }

--- a/src/commands/issueCommand.ts
+++ b/src/commands/issueCommand.ts
@@ -3,6 +3,7 @@ import { RestEndpointMethodTypes } from "@octokit/rest";
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
 import githubAPI from "../apis/githubAPI";
+import { getEmoji } from "../util/emoji";
 
 export class IssueCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -25,7 +26,8 @@ export class IssueCommand implements Command {
                 if (result) {
                     embed = this.embedFromIssue(parsedUserCommand, result);
                 } else {
-                    embed = "No matching issues found <:sadcaret:832714137166676018>";
+                    const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+                    embed = `No matching issues found ${sadcaret}`;
                 }
 
                 await parsedUserCommand.send(embed);
@@ -39,7 +41,8 @@ export class IssueCommand implements Command {
             const embed = this.embedFromIssue(parsedUserCommand, result);
             await parsedUserCommand.send(embed);
         } else {
-            await parsedUserCommand.send(`No matching issues found <:sadcaret:832714137166676018>`);
+            const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+            await parsedUserCommand.send(`No matching issues found ${sadcaret}`);
         }
     }
 

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -1,6 +1,7 @@
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
 import githubAPI from "../apis/githubAPI";
+import { getEmoji } from "../util/emoji";
 
 export class ManCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -22,9 +23,8 @@ export class ManCommand implements Command {
             if (result) {
                 await parsedUserCommand.send(`${result}`);
             } else {
-                await parsedUserCommand.send(
-                    `No matching man page found <:sadcaret:832714137166676018>`
-                );
+                const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+                await parsedUserCommand.send(`No matching man page found ${sadcaret}`);
             }
         }
     }

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -1,7 +1,7 @@
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
 import githubAPI from "../apis/githubAPI";
-import { getEmoji } from "../util/emoji";
+import { getSadCaret } from "../util/emoji";
 
 export class ManCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -23,7 +23,7 @@ export class ManCommand implements Command {
             if (result) {
                 await parsedUserCommand.send(`${result}`);
             } else {
-                const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+                const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
                 await parsedUserCommand.send(`No matching man page found ${sadcaret}`);
             }
         }

--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -3,7 +3,7 @@ import { RestEndpointMethodTypes } from "@octokit/rest";
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
 import githubAPI from "../apis/githubAPI";
-import { getEmoji } from "../util/emoji";
+import { getSadCaret } from "../util/emoji";
 
 export class PRCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -31,7 +31,7 @@ export class PRCommand implements Command {
                 if (result) {
                     embed = this.embedFromPr(parsedUserCommand, result);
                 } else {
-                    const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+                    const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
                     embed = `No matching PRs found ${sadcaret}`;
                 }
 
@@ -50,7 +50,7 @@ export class PRCommand implements Command {
             }
         }
 
-        const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+        const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
         await parsedUserCommand.send(`No matching pull requests found ${sadcaret}`);
     }
 

--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -3,6 +3,7 @@ import { RestEndpointMethodTypes } from "@octokit/rest";
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
 import githubAPI from "../apis/githubAPI";
+import { getEmoji } from "../util/emoji";
 
 export class PRCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -30,7 +31,8 @@ export class PRCommand implements Command {
                 if (result) {
                     embed = this.embedFromPr(parsedUserCommand, result);
                 } else {
-                    embed = "No matching PRs found <:sadcaret:832714137166676018>";
+                    const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+                    embed = `No matching PRs found ${sadcaret}`;
                 }
 
                 await parsedUserCommand.send(embed);
@@ -48,9 +50,8 @@ export class PRCommand implements Command {
             }
         }
 
-        await parsedUserCommand.send(
-            `No matching pull requests found <:sadcaret:832714137166676018>`
-        );
+        const sadcaret = getEmoji(parsedUserCommand.originalMessage, "sadcaret");
+        await parsedUserCommand.send(`No matching pull requests found ${sadcaret}`);
     }
 
     private embedFromPr(

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -7,3 +7,8 @@ export function getEmoji(message: Message, name: string): string | null {
     if (!emoji) return null;
     return emoji.toString();
 }
+
+/** Alias function fot the :sadcaret: emoji */
+export function getSadCaret(message: Message): string | null {
+    return getEmoji(message, "sadcaret");
+}

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -1,11 +1,25 @@
 import { Message } from "discord.js";
 
+const cache: Map<string, Map<string, string>> = new Map();
+
 /** Gets a displayable emoji string from the message's guild */
 export function getEmoji(message: Message, name: string): string | null {
+    // guid == null in dms, where we don't have access to custom emojis
     if (!message.guild) return null;
-    const emoji = message.guild.emojis.cache.find(emoji => emoji.name === name);
+
+    // check the cache first O(1)
+    const cached = cache.get(message.guild.id)?.get(name);
+    if (cached) return cached;
+
+    // otherwise check discord's emoji list
+    const emoji = message.guild.emojis.cache.find(emoji => emoji.name === name)?.toString();
     if (!emoji) return null;
-    return emoji.toString();
+
+    // cache found emoji for faster lookup later
+    if (!cache.get(message.guild.id)) cache.set(message.guild.id, new Map());
+    cache.get(message.guild.id)?.set(name, emoji);
+
+    return emoji;
 }
 
 /** Alias function fot the :sadcaret: emoji */

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -1,0 +1,9 @@
+import { Message } from "discord.js";
+
+/** Gets a displayable emoji string from the message's guild */
+export function getEmoji(message: Message, name: string): string | null {
+    if (!message.guild) return null;
+    const emoji = message.guild.emojis.cache.find(emoji => emoji.name === name);
+    if (!emoji) return null;
+    return emoji.toString();
+}


### PR DESCRIPTION
Based off of #11 
> In the future it might be beneficial to use the discordjs api somehow to not hardcode the emoji ID.

This pr creates a new function `getEmoji` which fetches the guild (server) in which a message was received for a custom emoji.
The feature is then used by the `issueCommand` and `prCommand` for the `:sadcaret:` emoji.
