### PR TITLE
CommandParser: Remove mentions and emotes from commands

### DIFF
--- a/src/models/commandParser.ts
+++ b/src/models/commandParser.ts
@@ -19,7 +19,11 @@ export class CommandParser {
 
     constructor(message: Message, prefix: string) {
         this.commandPrefix = prefix;
-        const splitMessage = message.content.slice(prefix.length).trim().split(/ +/g);
+        const splitMessage = message.content
+            .slice(prefix.length)
+            .replace(/<\S+>/g, "")
+            .trim()
+            .split(/ +/g);
         const commandName = splitMessage.shift() || "";
         this.parsedCommandName = commandName.toLowerCase();
         this.args = splitMessage;


### PR DESCRIPTION
Sometimes it is useful to ping someone while running a command, i.e.

!pr <pr number> @user

However, currently the bot includes the mention in the search, causing
some annoyance.  This patch removes anything between <> that's a single
word, which both emotes and mentions are.

This could probably be refined further by looking into the mentions
object within the message, but this shouldn't cause any false positives
during normal usage.