### PR TITLE
PrCommand: Minor improvements to the formatting of merged pull requests

### DIFF
--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -67,6 +67,8 @@ export class PRCommand implements Command {
 
         if (pr.draft) {
             color = "#768390";
+        } else if (pr.merged) {
+            color = "#6e40c9";
         } else {
             color = pr.state === "open" ? "#57ab5a" : "#e5534b";
         }

--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -83,6 +83,14 @@ export class PRCommand implements Command {
             .addField("Commits", `${pr.commits} (+${pr.additions} -${pr.deletions})`, true)
             .addField("Comments", pr.comments, true);
 
+        if (pr.merged && pr.merged_at && pr.merged_by) {
+            embed.addField(
+                "Merged",
+                `${new Date(pr.merged_at).toDateString()} by ${pr.merged_by.login}`,
+                true
+            );
+        }
+
         if (pr.user) {
             embed.setThumbnail(pr.user.avatar_url).setAuthor(pr.user.login);
         }


### PR DESCRIPTION
Previously even a merged pull request would be colored red
![image](https://user-images.githubusercontent.com/42888162/116197884-9338a380-a735-11eb-9656-0c13cca0ad3b.png)

This adds a new field containing when the pull request got merged and who merged it
![image](https://user-images.githubusercontent.com/42888162/116197992-b3686280-a735-11eb-9351-04948323fa00.png)
