### PR TITLE
ManCommand: Implement embed based format

### DIFF
--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -7,6 +7,13 @@
 import { Octokit } from "@octokit/rest";
 import { GITHUB_TOKEN } from "../config/secrets";
 
+export interface ManPage {
+    url: string;
+    section: string;
+    page: string;
+    markdown: string;
+}
+
 class GithubAPI {
     private octokit: Octokit;
 
@@ -78,7 +85,7 @@ class GithubAPI {
         }
     }
 
-    async fetch_serenity_manpage_by_url(url: string) {
+    async fetch_serenity_manpage_by_url(url: string): Promise<ManPage | undefined> {
         const pattern = /https:\/\/github\.com\/([\w/]*)\/blob\/master\/([\w/]*)\/man(\d)\/([\w/]*)\.md/;
         const result = url.match(pattern);
 
@@ -90,17 +97,22 @@ class GithubAPI {
     }
 
     /* Attempts to fetch the content of a man page. */
-    async fetch_serenity_manpage(section: string, page: string) {
-        const request_path = `GET /repos/${this.repository}/contents/${this.man_path}/man${section}/${page}.md`;
-        const results = await this.octokit.request(request_path);
-        const markdown = Buffer.from(results.data["content"], "base64").toString("binary");
+    async fetch_serenity_manpage(section: string, page: string): Promise<ManPage | undefined> {
+        try {
+            const path = `${this.man_path}/man${section}/${page}.md`;
+            const request_path = `GET /repos/${this.repository}/contents/${path}`;
+            const results = await this.octokit.request(request_path);
+            const markdown = Buffer.from(results.data["content"], "base64").toString("binary");
 
-        return {
-            url: `https://github.com/${this.repository}/blob/master/${this.man_path}/man${section}/${page}.md`,
-            section,
-            page,
-            markdown,
-        };
+            return {
+                url: `https://github.com/${this.repository}/blob/master/${path}`,
+                section,
+                page,
+                markdown,
+            };
+        } catch {
+            return;
+        }
     }
 }
 

--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -78,17 +78,27 @@ class GithubAPI {
         }
     }
 
+    async fetch_serenity_manpage_by_url(url: string) {
+        const pattern = /https:\/\/github\.com\/([\w\/]*)\/blob\/master\/([\w\/]*)\/man(\d)\/([\w\/]*)\.md/;
+        const result = url.match(pattern);
+
+        if (result === null) return;
+
+        if (result[1] !== this.repository || result[2] !== this.man_path) return;
+
+        return this.fetch_serenity_manpage(result[3], result[4]);
+    }
+
     /* Attempts to fetch the content of a man page. */
-    async fetch_serenity_manpage(
-        section: string,
-        page: string
-    ): Promise<{ url: string; markdown: string }> {
+    async fetch_serenity_manpage(section: string, page: string) {
         const request_path = `GET /repos/${this.repository}/contents/${this.man_path}/man${section}/${page}.md`;
         const results = await this.octokit.request(request_path);
         const markdown = Buffer.from(results.data["content"], "base64").toString("binary");
 
         return {
             url: `https://github.com/${this.repository}/blob/master/${this.man_path}/man${section}/${page}.md`,
+            section,
+            page,
             markdown,
         };
     }

--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -5,7 +5,6 @@
  */
 
 import { Octokit } from "@octokit/rest";
-import { Util } from "discord.js";
 import { GITHUB_TOKEN } from "../config/secrets";
 
 class GithubAPI {
@@ -80,27 +79,18 @@ class GithubAPI {
     }
 
     /* Attempts to fetch the content of a man page. */
-    async fetch_serenity_manpage(section: string, page: string): Promise<string> {
+    async fetch_serenity_manpage(
+        section: string,
+        page: string
+    ): Promise<{ url: string; markdown: string }> {
         const request_path = `GET /repos/${this.repository}/contents/${this.man_path}/man${section}/${page}.md`;
         const results = await this.octokit.request(request_path);
         const markdown = Buffer.from(results.data["content"], "base64").toString("binary");
 
-        return this.envelope_in_markdown(markdown);
-    }
-
-    /* Utility to envelope content in markdown, including escaping code blocks. */
-    private async envelope_in_markdown(markdown: string): Promise<string> {
-        /* Escape code blocks so they don't break up the markdown message. */
-        markdown = Util.cleanCodeBlockContent(markdown);
-
-        /* Wrap the content in a markdown envelope. */
-        markdown = "```markdown\n" + markdown;
-
-        /* Discord only supports up to 2000 characters for messages. */
-        markdown = markdown.substr(0, Math.min(markdown.length, 2000 - 8));
-        markdown = markdown + "\n```";
-
-        return markdown;
+        return {
+            url: `https://github.com/${this.repository}/blob/master/${this.man_path}/man${section}/${page}.md`,
+            markdown,
+        };
     }
 }
 

--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -79,7 +79,7 @@ class GithubAPI {
     }
 
     async fetch_serenity_manpage_by_url(url: string) {
-        const pattern = /https:\/\/github\.com\/([\w\/]*)\/blob\/master\/([\w\/]*)\/man(\d)\/([\w\/]*)\.md/;
+        const pattern = /https:\/\/github\.com\/([\w/]*)\/blob\/master\/([\w/]*)\/man(\d)\/([\w/]*)\.md/;
         const result = url.match(pattern);
 
         if (result === null) return;

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -32,8 +32,10 @@ export class ManCommand implements Command {
         } else {
             const section = args[0];
             const page = args[1];
-            const { markdown, url } = await githubAPI.fetch_serenity_manpage(section, page);
-            if (markdown) {
+            const result = await githubAPI.fetch_serenity_manpage(section, page);
+
+            if (result) {
+                const { markdown, url } = result;
                 const message: Message = await parsedUserCommand.send(
                     ManCommand.embedForMan(markdown, url, section, page, true)
                 );

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -4,10 +4,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import Command from "./commandInterface";
-import { CommandParser } from "../models/commandParser";
+import { MessageEmbed } from "discord.js";
 import githubAPI from "../apis/githubAPI";
+import { CommandParser } from "../models/commandParser";
 import { getSadCaret } from "../util/emoji";
+import Command from "./commandInterface";
+
+interface Paragraph {
+    title?: string;
+    content: string;
+    truncateFollowingLines?: boolean;
+}
 
 export class ManCommand implements Command {
     matchesName(commandName: string): boolean {
@@ -25,13 +32,73 @@ export class ManCommand implements Command {
         } else {
             const section = args[0];
             const page = args[1];
-            const result = await githubAPI.fetch_serenity_manpage(section, page);
-            if (result) {
-                await parsedUserCommand.send(`${result}`);
+            const { markdown, url } = await githubAPI.fetch_serenity_manpage(section, page);
+            if (markdown) {
+                await parsedUserCommand.send(
+                    this.embedForMan(parsedUserCommand, markdown, url, page)
+                );
             } else {
                 const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
                 await parsedUserCommand.send(`No matching man page found ${sadcaret}`);
             }
         }
+    }
+
+    embedForMan(
+        parsedUserCommand: CommandParser,
+        markdown: string,
+        url: string,
+        page: string
+    ): MessageEmbed {
+        const paragraphs: Array<Paragraph> = new Array<Paragraph>();
+
+        let currentParagraph: Paragraph = { content: "" };
+        let truncated = false;
+        let name: string | undefined;
+
+        for (let line of markdown.split("\n")) {
+            if (line.startsWith("## ")) {
+                if (currentParagraph.content !== "") {
+                    if (currentParagraph.title === "Name") {
+                        name = currentParagraph.content;
+                    } else {
+                        paragraphs.push(currentParagraph);
+                    }
+                }
+
+                currentParagraph = { content: "" };
+
+                currentParagraph.title = line.substring(3).trim();
+            } else if (!currentParagraph.truncateFollowingLines) {
+                if (currentParagraph.content.length + line.length + 4 > 1024) {
+                    currentParagraph.content += "\n...";
+                    currentParagraph.truncateFollowingLines = true;
+                    truncated = true;
+                } else {
+                    if (line.startsWith("```")) line = line.replace(/\*/g, "");
+
+                    currentParagraph.content += line + "\n";
+                }
+            }
+        }
+
+        const embed = parsedUserCommand
+            .embed()
+            .setTitle(page)
+            .setDescription(name ?? "Name not found")
+            .setURL(url);
+
+        for (const paragraph of paragraphs)
+            if (paragraph.title) embed.addField(paragraph.title, paragraph.content);
+
+        if (truncated)
+            embed.setFooter(
+                `The following paragraphs have been truncated: ${paragraphs
+                    .filter(paragraph => paragraph.title ?? paragraph.truncateFollowingLines)
+                    .map(paragraph => paragraph.title)
+                    .join(", ")}`
+            );
+
+        return embed;
     }
 }

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -35,10 +35,10 @@ export class ManCommand implements Command {
             const { markdown, url } = await githubAPI.fetch_serenity_manpage(section, page);
             if (markdown) {
                 const message: Message = await parsedUserCommand.send(
-                    ManCommand.embedForMan(markdown, url, page, true)
+                    ManCommand.embedForMan(markdown, url, section, page, true)
                 );
-                const maximizeEmote: string | null = getMaximize(message);
-                const minimizeEmote: string | null = getMinimize(message);
+                const maximizeEmote = getMaximize(message);
+                const minimizeEmote = getMinimize(message);
 
                 if (maximizeEmote) message.react(maximizeEmote);
                 if (minimizeEmote) message.react(minimizeEmote);
@@ -52,6 +52,7 @@ export class ManCommand implements Command {
     static embedForMan(
         markdown: string,
         url: string,
+        section: string,
         page: string,
         collapsed: boolean
     ): MessageEmbed {
@@ -88,7 +89,7 @@ export class ManCommand implements Command {
         }
 
         const embed = new MessageEmbed()
-            .setTitle(page)
+            .setTitle(`${page}(${section})`)
             .setDescription(name ?? "Name not found")
             .setURL(url)
             .setTimestamp();
@@ -100,7 +101,7 @@ export class ManCommand implements Command {
         if (truncated && !collapsed)
             embed.setFooter(
                 `The following paragraphs have been truncated: ${paragraphs
-                    .filter(paragraph => paragraph.title ?? paragraph.truncateFollowingLines)
+                    .filter(paragraph => paragraph.title && paragraph.truncateFollowingLines)
                     .map(paragraph => paragraph.title)
                     .join(", ")}`
             );

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,9 @@ client.on("messageReactionAdd", async (reaction: MessageReaction, user: User | P
 
         if (!result) return;
 
-        const { markdown, url, page } = result;
+        const { markdown, url, page, section } = result;
 
-        message.edit(ManCommand.embedForMan(markdown, url, page, collapsed));
+        message.edit(ManCommand.embedForMan(markdown, url, section, page, collapsed));
 
         reaction.users.remove(user.id);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import Discord, { Message } from "discord.js";
-import { DISCORD_TOKEN } from "./config/secrets";
+import Discord, { Message, MessageEmbed, MessageReaction, PartialUser, User } from "discord.js";
+import githubAPI from "./apis/githubAPI";
 import CommandHandler from "./commandHandler";
+import { ManCommand } from "./commands";
 import config from "./config/botConfig";
+import { DISCORD_TOKEN } from "./config/secrets";
 
-const client = new Discord.Client();
+const client = new Discord.Client({ partials: ["MESSAGE", "CHANNEL", "REACTION"] });
 
 const commandHandler = new CommandHandler(config.prefix, config.production);
 
@@ -27,6 +29,39 @@ client.on("ready", () => {
 });
 client.on("message", (message: Message) => {
     commandHandler.handleMessage(message);
+});
+client.on("messageReactionAdd", async (reaction: MessageReaction, user: User | PartialUser) => {
+    const message: Message = await reaction.message.fetch();
+
+    if (reaction.partial) reaction = await reaction.fetch();
+
+    const collapsed: boolean | undefined =
+        reaction.emoji.name === "minimize"
+            ? true
+            : reaction.emoji.name === "maximize"
+            ? false
+            : undefined;
+
+    if (collapsed === undefined) return;
+
+    if (user.id === client.user?.id) return;
+    if (message.author.id !== client.user?.id) return;
+
+    if (message.embeds.length === 1) {
+        const embed: MessageEmbed = message.embeds[0];
+
+        if (!embed.url) return;
+
+        const result = await githubAPI.fetch_serenity_manpage_by_url(embed.url);
+
+        if (!result) return;
+
+        const { markdown, url, page } = result;
+
+        message.edit(ManCommand.embedForMan(markdown, url, page, collapsed));
+
+        reaction.users.remove(user.id);
+    }
 });
 client.on("error", e => {
     console.error("Discord client error!", e);

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -32,3 +32,13 @@ export function getEmoji(message: Message, name: string): string | null {
 export function getSadCaret(message: Message): string | null {
     return getEmoji(message, "sadcaret");
 }
+
+/** Alias function for the :maximize: emoji */
+export function getMaximize(message: Message): string | null {
+    return getEmoji(message, "maximize");
+}
+
+/** Alias function for the :minimize: emoji */
+export function getMinimize(message: Message): string | null {
+    return getEmoji(message, "minimize");
+}


### PR DESCRIPTION
- Send an Embed instead of a markdown codeblock for a man page
- Add emojis to be able to toggle between a collapsed and an extended view

Collapsed:
![image](https://user-images.githubusercontent.com/42888162/116251261-cb100d00-a76e-11eb-97b2-6f3e3137653a.png)

Expanded:
![image](https://user-images.githubusercontent.com/42888162/116251298-d6633880-a76e-11eb-9cea-c4dbf9a778cf.png)
