### PR TITLE
Util+Commands: Cache emojis based on a globally configured guild

### DIFF
--- a/src/commands/issueCommand.ts
+++ b/src/commands/issueCommand.ts
@@ -32,7 +32,7 @@ export class IssueCommand implements Command {
                 if (result) {
                     embed = this.embedFromIssue(parsedUserCommand, result);
                 } else {
-                    const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
+                    const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
                     embed = `No matching issues found ${sadcaret}`;
                 }
 
@@ -47,7 +47,7 @@ export class IssueCommand implements Command {
             const embed = this.embedFromIssue(parsedUserCommand, result);
             await parsedUserCommand.send(embed);
         } else {
-            const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
+            const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
             await parsedUserCommand.send(`No matching issues found ${sadcaret}`);
         }
     }

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -39,13 +39,13 @@ export class ManCommand implements Command {
                 const message: Message = await parsedUserCommand.send(
                     ManCommand.embedForMan(markdown, url, section, page, true)
                 );
-                const maximizeEmote = getMaximize(message);
-                const minimizeEmote = getMinimize(message);
+                const maximizeEmote = await getMaximize(message);
+                const minimizeEmote = await getMinimize(message);
 
-                if (maximizeEmote) message.react(maximizeEmote);
-                if (minimizeEmote) message.react(minimizeEmote);
+                if (maximizeEmote) message.react(maximizeEmote.identifier);
+                if (minimizeEmote) message.react(minimizeEmote.identifier);
             } else {
-                const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
+                const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
                 await parsedUserCommand.send(`No matching man page found ${sadcaret}`);
             }
         }

--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -37,7 +37,7 @@ export class PRCommand implements Command {
                 if (result) {
                     embed = this.embedFromPr(parsedUserCommand, result);
                 } else {
-                    const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
+                    const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
                     embed = `No matching PRs found ${sadcaret}`;
                 }
 
@@ -56,7 +56,7 @@ export class PRCommand implements Command {
             }
         }
 
-        const sadcaret = getSadCaret(parsedUserCommand.originalMessage);
+        const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
         await parsedUserCommand.send(`No matching pull requests found ${sadcaret}`);
     }
 

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: ".env" });
 
 export const DISCORD_TOKEN = process.env["discord_token"];
 export const GITHUB_TOKEN = process.env["github_token"];
+export let GUILD_ID = process.env["guild_id"];
 
 if (!DISCORD_TOKEN) {
     console.error("No 'discord token' provided in .env file.");
@@ -18,4 +19,9 @@ if (!GITHUB_TOKEN) {
     console.error(
         "No 'github token' provided in .env file, the rate limit will be greatly reduced!"
     );
+}
+if (!GUILD_ID) {
+    console.warn("No 'guild id' provided in .env file, using id of the SerenityOS guild.");
+
+    GUILD_ID = "830522505605283862";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import CommandHandler from "./commandHandler";
 import { ManCommand } from "./commands";
 import config from "./config/botConfig";
 import { DISCORD_TOKEN } from "./config/secrets";
+import { getMaximize, getMinimize } from "./util/emoji";
 
 const client = new Discord.Client({ partials: ["MESSAGE", "CHANNEL", "REACTION"] });
 
@@ -36,9 +37,9 @@ client.on("messageReactionAdd", async (reaction: MessageReaction, user: User | P
     if (reaction.partial) reaction = await reaction.fetch();
 
     const collapsed: boolean | undefined =
-        reaction.emoji.name === "minimize"
+        reaction.emoji === (await getMinimize(client))
             ? true
-            : reaction.emoji.name === "maximize"
+            : reaction.emoji === (await getMaximize(client))
             ? false
             : undefined;
 


### PR DESCRIPTION
Previously the emoji cache wouldn't work in private message channels
due to it using a message's guild to resolve an emoji.

As Buggie is currently the only instance of the bot and as said
instance is only being used on the Serenity server there is no
problem in taking a guild as a config variable.

The emoji cache now also not only caches the emoji's name but the whole
reference object.

Resolves #21
