### PR TITLE
Add !plan to check if a feature is part of the SerenityOS plan

### DIFF
--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -5,7 +5,7 @@
  */
 
 import { Message } from "discord.js";
-import { IssueCommand, ManCommand, PRCommand, QuickLinksCommand } from "./commands";
+import { IssueCommand, ManCommand, PlanCommand, PRCommand, QuickLinksCommand } from "./commands";
 import Command from "./commands/commandInterface";
 import { CommandParser } from "./models/commandParser";
 
@@ -17,7 +17,13 @@ export default class CommandHandler {
     private readonly production: boolean;
 
     constructor(prefix: string, production: boolean) {
-        const commandClasses = [IssueCommand, ManCommand, PRCommand, QuickLinksCommand];
+        const commandClasses = [
+            IssueCommand,
+            ManCommand,
+            PlanCommand,
+            PRCommand,
+            QuickLinksCommand,
+        ];
 
         this.commands = commandClasses.map(commandClass => new commandClass());
         this.prefix = prefix;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -19,5 +19,6 @@
 
 export * from "./issueCommand";
 export * from "./manCommand";
+export * from "./planCommand";
 export * from "./prCommand";
 export * from "./quickLinksCommand";

--- a/src/commands/planCommand.ts
+++ b/src/commands/planCommand.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import Command from "./commandInterface";
+import { CommandParser } from "../models/commandParser";
+
+export class PlanCommand implements Command {
+    private readonly baseReply: string = `> Will SerenityOS support \`$THING\`?\nMaybe. Maybe not. There is no plan.\n(source: <https://github.com/SerenityOS/serenity/blob/master/Documentation/FAQ.md>)`;
+    matchesName(commandName: string): boolean {
+        return "plan" == commandName;
+    }
+
+    help(commandPrefix: string): string {
+        return `Use **${commandPrefix}plan [ <feature> ]** to check if a feature is part of the plan`;
+    }
+
+    async run(parsedUserCommand: CommandParser): Promise<void> {
+        let reply = this.baseReply;
+        const args = parsedUserCommand.args;
+        if (args.length > 1) {
+            reply = reply.replace("`$THING`", args.slice(1).join(" "));
+        }
+
+        await parsedUserCommand.send(reply);
+        try {
+            await parsedUserCommand.originalMessage.delete();
+        } catch (e) {
+            // noop catch to ignore permission errors when deleting messages of higher rank users
+        }
+    }
+}


### PR DESCRIPTION
Example usage :

User: `!plan hardware acceleration`

Bot :
```
> Will SerenityOS support hardware acceleration?
Maybe. Maybe not. There is no plan.
(source: <https://github.com/SerenityOS/serenity/blob/master/Documentation/FAQ.md>)
```

Also works without arguments to use the original "Will SerenityOS support `$THING`?" question.