### PR TITLE
Commands: Added the test262 command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/SerenityOS/discord-bot#readme",
   "devDependencies": {
     "@octokit/types": "^6.16.2",
+    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "eslint": "^7.27.0",
@@ -53,6 +54,7 @@
     "@types/node": "^15.12.0",
     "discord.js": "^12.2.0",
     "dotenv": "^10.0.0",
+    "node-fetch": "^2.6.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.3.2"
   }

--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -86,6 +86,22 @@ class GithubAPI {
         }
     }
 
+    async searchCommit(commitHash: string) {
+        try {
+            const results = await this.octokit.request(
+                "GET /repos/{owner}/{repo}/git/commits/{commit_sha}",
+                {
+                    commit_sha: commitHash,
+                    owner: "SerenityOS",
+                    repo: "serenity",
+                }
+            );
+            return results.data;
+        } catch {
+            return undefined;
+        }
+    }
+
     async fetchSerenityManpageByUrl(url: string): Promise<ManPage | undefined> {
         const pattern =
             /https:\/\/github\.com\/([\w/]*)\/blob\/master\/([\w/]*)\/man(\d)\/([\w/]*)\.md/;

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -5,7 +5,14 @@
  */
 
 import { Message } from "discord.js";
-import { IssueCommand, ManCommand, PlanCommand, PRCommand, QuickLinksCommand } from "./commands";
+import {
+    IssueCommand,
+    ManCommand,
+    PlanCommand,
+    PRCommand,
+    QuickLinksCommand,
+    Test262Command,
+} from "./commands";
 import Command from "./commands/commandInterface";
 import { CommandParser } from "./models/commandParser";
 
@@ -23,6 +30,7 @@ export default class CommandHandler {
             PlanCommand,
             PRCommand,
             QuickLinksCommand,
+            Test262Command,
         ];
 
         this.commands = commandClasses.map(commandClass => new commandClass());

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,3 +22,4 @@ export * from "./manCommand";
 export * from "./planCommand";
 export * from "./prCommand";
 export * from "./quickLinksCommand";
+export * from "./test262Command";

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { MessageEmbed } from "discord.js";
+import fetch from "node-fetch";
+import githubAPI from "../apis/githubAPI";
+import { CommandParser } from "../models/commandParser";
+import Command from "./commandInterface";
+
+/* eslint-disable camelcase */
+interface Result {
+    commit_timestamp: number;
+    run_timestamp: number;
+    versions: {
+        serenity: string;
+        "libjs-test262": string;
+        test262: string;
+        "test262-parser-tests": string;
+    };
+    tests: {
+        [name: string]: {
+            duration: number;
+            results: {
+                [label: string]: number;
+            };
+        };
+    };
+}
+/* eslint-enable camelcase */
+
+export class Test262Command implements Command {
+    matchesName(commandName: string): boolean {
+        return "test262" === commandName;
+    }
+
+    help(commandPrefix: string): string {
+        return `Use **${commandPrefix}test262 [ commitHash | "labels" ]** to display libjs test262 results`;
+    }
+
+    async run(parsedUserCommand: CommandParser): Promise<void> {
+        const results: Array<Result> = await (
+            await fetch("https://libjs.dev/test262/data/results.json")
+        ).json();
+
+        const args = parsedUserCommand.args;
+
+        let result: Result = results[results.length - 1];
+        let previousResult: Result = results[results.length - 2];
+
+        if (args.length === 1) {
+            if (args[0] === "labels") {
+                await parsedUserCommand.send(
+                    new MessageEmbed().setDescription(
+                        Array.from(Test262Command.statusIconByLabel)
+                            .map(([key, icon]) => `${icon}: ${key}`)
+                            .join("\n")
+                    )
+                );
+
+                return;
+            }
+
+            for (let i = 0; i < results.length; i++) {
+                if (results[i].versions.serenity.startsWith(args[0])) {
+                    result = results[i];
+                    previousResult = results[i - 1];
+
+                    break;
+                }
+            }
+        }
+
+        await parsedUserCommand.send(await Test262Command.embedForResult(result, previousResult));
+    }
+
+    static statusIconByLabel = new Map<string, string>([
+        ["total", "🧪"],
+        ["passed", "✅"],
+        ["failed", "❌"],
+        ["skipped", "⚠️"],
+        ["metadata_error", "📄"],
+        ["harness_error", "⚙️"],
+        ["timeout_error", "💀"],
+        ["process_error", "💥️"],
+        ["runner_exception", "🐍"],
+    ]);
+
+    static repositoryUrlByName = new Map<string, string>([
+        ["serenity", "https://github.com/SerenityOS/serenity/"],
+        ["libjs-test262", "https://github.com/linusg/libjs-test262/"],
+        ["test262", "https://github.com/tc39/test262/"],
+        ["test262-parser-tests", "https://github.com/tc39/test262-parser-tests/"],
+    ]);
+
+    static async embedForResult(result: Result, previousResult?: Result): Promise<MessageEmbed> {
+        const commit = await githubAPI.searchCommit(result.versions.serenity);
+
+        const embed = new MessageEmbed()
+            .setTitle(commit?.message.split("\n")[0])
+            .setDescription(
+                Object.entries(result.versions)
+                    .map(([repository, commit]) => {
+                        const treeUrl = Test262Command.repositoryUrlByName.get(repository);
+                        const shortCommit = commit.substring(0, 7);
+
+                        if (treeUrl)
+                            return `${repository}: [${shortCommit}](${treeUrl}tree/${commit})`;
+
+                        return `${repository}: ${shortCommit}`;
+                    })
+                    .join("\n")
+            )
+            .setTimestamp(new Date(result.run_timestamp * 1000))
+            .setFooter("Tests started");
+
+        for (const [name, test] of Object.entries(result.tests)) {
+            const percentage = test.results.passed / (test.results.total / 100);
+
+            embed.addField(
+                `${name} (${percentage.toFixed(2)}%, ${test.duration.toFixed(2)}s)`,
+                Object.entries(test.results)
+                    .map(([label, value]) => {
+                        const previous = previousResult?.tests[name]?.results[label];
+                        const icon = Test262Command.statusIconByLabel.get(label) ?? label;
+
+                        if (previous && previous - value !== 0) {
+                            const difference = value - previous;
+
+                            return `${icon} ${value} (${difference > 0 ? "+" : ""}${difference})`;
+                        }
+
+                        return `${icon} ${value}`;
+                    })
+                    .join(" | "),
+                false
+            );
+        }
+
+        return embed;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,19 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/node-fetch@^2.5.10":
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
+  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
+"@types/node@*":
+  version "15.12.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.1.tgz#9b60797dee1895383a725f828a869c86c6caa5c2"
+  integrity sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==
+
 "@types/node@^15.12.0":
   version "15.12.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.0.tgz#6a459d261450a300e6865faeddb5af01c3389bb3"
@@ -951,6 +964,15 @@ flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This command fetches and outputs the results of the ecma262 tests
run in LibJS from https://libjs.dev/test262.

If no argument is given, the latest commit will be used. Otherwise
the first argument will be used to resolve a commit by hash.

If the first argument is "labels", an overview over the icons
used in the result output will be displayed.
