### PR TITLE
Commands: Inline passing percentage of test262 test with other values

### DIFF
--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -86,3 +86,8 @@ export async function getYaksplode(clientOrParent: ClientOrParent): Promise<Emoj
 export async function getNeoyak(clientOrParent: ClientOrParent): Promise<Emoji | null> {
     return await getEmoji(clientOrParent, "neoyak");
 }
+
+/** Alias function for the :libjs: emoji */
+export async function getLibjs(clientOrParent: ClientOrParent): Promise<Emoji | null> {
+    return await getEmoji(clientOrParent, "libjs");
+}


### PR DESCRIPTION
This moves the percentage value of passed tests from the title
of a test's embed field to the first entry in the body.

Additionally, a percentage difference to the previous commit is now shown :^)
