### PR TITLE
Commands: Add emoji command

### DIFF
--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -12,6 +12,7 @@ import {
     PRCommand,
     QuickLinksCommand,
     Test262Command,
+    EmojiCommand,
 } from "./commands";
 import Command from "./commands/commandInterface";
 import { CommandParser } from "./models/commandParser";
@@ -31,6 +32,7 @@ export default class CommandHandler {
             PRCommand,
             QuickLinksCommand,
             Test262Command,
+            EmojiCommand,
         ];
 
         this.commands = commandClasses.map(commandClass => new commandClass());

--- a/src/commands/emojiCommand.ts
+++ b/src/commands/emojiCommand.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import Command from "./commandInterface";
+import { CommandParser } from "../models/commandParser";
+import { getEmoji, getThonk } from "../util/emoji";
+
+export class EmojiCommand implements Command {
+    matchesName(commandName: string): boolean {
+        return "emoji" === commandName;
+    }
+
+    help(commandPrefix: string): string {
+        return `Use **${commandPrefix}emoji <name>** to make Buggie post an emoji`;
+    }
+
+    async run(parsedUserCommand: CommandParser): Promise<void> {
+        const args = parsedUserCommand.args;
+
+        if (args.length !== 1) {
+            await parsedUserCommand.send("Error: One argument required");
+            return;
+        }
+
+        const result = await getEmoji(parsedUserCommand.originalMessage, args[0]);
+
+        if (result) {
+            await parsedUserCommand.send(result.toString());
+        } else {
+            const thonk = await getThonk(parsedUserCommand.originalMessage);
+            if (thonk?.id) await parsedUserCommand.originalMessage.react(thonk.id);
+        }
+    }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -23,3 +23,4 @@ export * from "./planCommand";
 export * from "./prCommand";
 export * from "./quickLinksCommand";
 export * from "./test262Command";
+export * from "./emojiCommand";

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -91,3 +91,8 @@ export async function getNeoyak(clientOrParent: ClientOrParent): Promise<Emoji |
 export async function getLibjs(clientOrParent: ClientOrParent): Promise<Emoji | null> {
     return await getEmoji(clientOrParent, "libjs");
 }
+
+/** Alias function for the :thonk: emoji */
+export async function getThonk(clientOrParent: ClientOrParent): Promise<Emoji | null> {
+    return await getEmoji(clientOrParent, "thonk");
+}


### PR DESCRIPTION
This command allows non nitro users to send animated emojis (or any emoji)
from the configured guild into the current chat
