### PR TITLE
Add author to test262 embed

### DIFF
--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -89,7 +89,7 @@ class GithubAPI {
     async searchCommit(commitHash: string) {
         try {
             const results = await this.octokit.request(
-                "GET /repos/{owner}/{repo}/git/commits/{commit_sha}",
+                "GET /repos/{owner}/{repo}/commits/{commit_sha}",
                 {
                     commit_sha: commitHash,
                     owner: "SerenityOS",

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -161,7 +161,7 @@ export class Test262Command implements Command {
         const commit = await githubAPI.searchCommit(result.versions.serenity);
 
         const embed = new MessageEmbed()
-            .setTitle(commit?.message.split("\n")[0])
+            .setTitle(commit?.commit.message.split("\n")[0])
             .setDescription(
                 Object.entries(result.versions)
                     .map(([repository, commit]) => {

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -173,6 +173,11 @@ export class Test262Command implements Command {
             .join("\n");
 
         const embed = new MessageEmbed()
+            .setAuthor(
+                `@${commit?.author.login}`,
+                commit?.author.avatar_url,
+                commit?.author.html_url
+            )
             .setTitle(commit?.commit.message.split("\n")[0])
             .setDescription(description)
             .setTimestamp(new Date(result.run_timestamp * 1000))

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -160,21 +160,21 @@ export class Test262Command implements Command {
     ): Promise<MessageEmbed> {
         const commit = await githubAPI.searchCommit(result.versions.serenity);
 
+        const description = Object.entries(result.versions)
+            .map(([repository, commitHash]) => {
+                const treeUrl = Test262Command.repositoryUrlByName.get(repository);
+                const shortCommitHash = commitHash.substring(0, 7);
+
+                if (treeUrl)
+                    return `${repository}: [${shortCommitHash}](${treeUrl}tree/${commitHash})`;
+
+                return `${repository}: ${shortCommitHash}`;
+            })
+            .join("\n");
+
         const embed = new MessageEmbed()
             .setTitle(commit?.commit.message.split("\n")[0])
-            .setDescription(
-                Object.entries(result.versions)
-                    .map(([repository, commit]) => {
-                        const treeUrl = Test262Command.repositoryUrlByName.get(repository);
-                        const shortCommit = commit.substring(0, 7);
-
-                        if (treeUrl)
-                            return `${repository}: [${shortCommit}](${treeUrl}tree/${commit})`;
-
-                        return `${repository}: ${shortCommit}`;
-                    })
-                    .join("\n")
-            )
+            .setDescription(description)
             .setTimestamp(new Date(result.run_timestamp * 1000))
             .setFooter("Tests started");
 


### PR DESCRIPTION
I always wished it would show the commit author so it doesn't look like it's my work when invoking the `!test262` command. Now it does :^)

![image](https://user-images.githubusercontent.com/19366641/124747190-98765380-df19-11eb-8bb5-eb2b9a7d4bed.png)
