### PR TITLE
Commands: Search for pull requests and issues by first argument if number

### DIFF
--- a/src/commands/issueCommand.ts
+++ b/src/commands/issueCommand.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { MessageEmbed } from "discord.js";
 import { RestEndpointMethodTypes } from "@octokit/rest";
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
@@ -22,22 +21,13 @@ export class IssueCommand implements Command {
 
     async run(parsedUserCommand: CommandParser): Promise<void> {
         const args = parsedUserCommand.args;
+        const number = Number(args[0]);
 
-        if (args.length == 1) {
-            const number = Number(args[0]);
-            if (!isNaN(number)) {
-                const result = await githubAPI.searchIssue(number);
-                let embed: MessageEmbed | string;
+        if (!isNaN(number)) {
+            const result = await githubAPI.searchIssue(number);
 
-                if (result != null) {
-                    embed = this.embedFromIssue(parsedUserCommand, result);
-                } else {
-                    const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
-                    embed = `No matching issues found ${sadcaret}`;
-                }
-
-                await parsedUserCommand.send(embed);
-
+            if (result != null) {
+                await parsedUserCommand.send(this.embedFromIssue(parsedUserCommand, result));
                 return;
             }
         }

--- a/src/commands/prCommand.ts
+++ b/src/commands/prCommand.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { MessageEmbed } from "discord.js";
 import { RestEndpointMethodTypes } from "@octokit/rest";
 import Command from "./commandInterface";
 import { CommandParser } from "../models/commandParser";
@@ -27,22 +26,13 @@ export class PRCommand implements Command {
 
     async run(parsedUserCommand: CommandParser): Promise<void> {
         const args = parsedUserCommand.args;
+        const number = Number(args[0]);
 
-        if (args.length == 1) {
-            const number = Number(args[0]);
-            if (!isNaN(number)) {
-                const result = await githubAPI.searchPullRequest(number);
-                let embed: MessageEmbed | string;
+        if (!isNaN(number)) {
+            const result = await githubAPI.searchPullRequest(number);
 
-                if (result != null) {
-                    embed = this.embedFromPr(parsedUserCommand, result);
-                } else {
-                    const sadcaret = await getSadCaret(parsedUserCommand.originalMessage);
-                    embed = `No matching PRs found ${sadcaret}`;
-                }
-
-                await parsedUserCommand.send(embed);
-
+            if (result != null) {
+                await parsedUserCommand.send(this.embedFromPr(parsedUserCommand, result));
                 return;
             }
         }


### PR DESCRIPTION
This prevents a github api error being thrown for using more than
256 characters in a command with the following pattern:

`!pr <number> <message about the pr...>`
`!issue <number> <message about the issue...>`
