### PR TITLE
Commands: Add "wen" alias for "plan"

### DIFF
--- a/src/commands/planCommand.ts
+++ b/src/commands/planCommand.ts
@@ -10,7 +10,7 @@ import { CommandParser } from "../models/commandParser";
 export class PlanCommand implements Command {
     private readonly baseReply: string = `> Will SerenityOS support \`$THING\`?\nMaybe. Maybe not. There is no plan.\n\nSee: [FAQ](https://github.com/SerenityOS/serenity/blob/master/Documentation/FAQ.md)`;
     matchesName(commandName: string): boolean {
-        return "plan" == commandName;
+        return "plan" == commandName || "wen" == commandName;
     }
 
     help(commandPrefix: string): string {


### PR DESCRIPTION
This is kind of a meme on Discord where "wen" is commonly used when
asking for features. As this is the purpose of the "plan" command, an
alias "wen" could make the use of "plan" much funnier.