### PR TITLE
Commands: Fix text encoding of the /quote command

### DIFF
--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -131,7 +131,7 @@ class GithubAPI {
     async fetchSerenityFortunes(): Promise<Fortune[]> {
         const requestPath = `GET /repos/${this.repository}/contents/${this.fortunesPath}`;
         const results = await this.octokit.request(requestPath);
-        const json = Buffer.from(results.data["content"], "base64").toString("binary");
+        const json = Buffer.from(results.data["content"], "base64").toString("utf-8");
         return JSON.parse(json);
     }
 
@@ -149,7 +149,10 @@ class GithubAPI {
             changes: [
                 {
                     files: {
-                        [this.fortunesPath]: json + "\n",
+                        [this.fortunesPath]: {
+                            content: json + "\n",
+                            encoding: "utf-8",
+                        },
                     },
                     commit: "Base: Add a quote to the fortunes database\n\n[skip ci]",
                 },


### PR DESCRIPTION
Because the quote command was encoding the fortunes.json file as
binary when it received it from the API it was mangling the utf-8
characters in the file when it it wrote it back when creating the
pull request.

Fix this by always using utf-8 encoding.