### PR TITLE
Revert "Dependencies: Bump node-fetch from 2.6.1 to 3.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "bufferutil": "^4.0.3",
     "discord.js": "^13.1.0",
     "dotenv": "^10.0.0",
-    "node-fetch": "^3.0.0",
+    "node-fetch": "^2.6.1",
     "octokit-plugin-create-pull-request": "^3.9.3",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.2",

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -75,9 +75,9 @@ export class Test262Command extends Command {
     override async run(interaction: BaseCommandInteraction): Promise<void> {
         if (!interaction.isCommand()) return;
 
-        const results = (await (
+        const results: Array<Result> = await (
             await fetch("https://libjs.dev/test262/data/results.json")
-        ).json()) as Result[];
+        ).json();
 
         let result: Result = results[results.length - 1];
         let previousResult: Result = results[results.length - 2];

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,11 +661,6 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-data-uri-to-buffer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
-  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
-
 debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1003,13 +998,6 @@ fastq@^1.6.0:
   integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   dependencies:
     reusify "^1.0.4"
-
-fetch-blob@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.2.tgz#6bc438675f3851ecea51758ac91f6a1cd1bacabd"
-  integrity sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==
-  dependencies:
-    web-streams-polyfill "^3.0.3"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -1478,14 +1466,6 @@ node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0.tgz#79da7146a520036f2c5f644e4a26095f17e411ea"
-  integrity sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==
-  dependencies:
-    data-uri-to-buffer "^3.0.1"
-    fetch-blob "^3.1.2"
 
 node-gyp-build@^4.2.0:
   version "4.2.3"
@@ -2033,11 +2013,6 @@ vali-date@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
   integrity sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=
-
-web-streams-polyfill@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz#86f983b4f44745502b0d8563d9ef3afc609d4465"
-  integrity sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Reverts SerenityOS/discord-bot#212 

This is breaking the `test262` command with the following error: 
```
2021-09-04T18:20:54.915930+00:00 app[worker.1]: Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/node-fetch/src/index.js from /app/build/commands/test262Command.js not supported.
2021-09-04T18:20:54.915933+00:00 app[worker.1]: Instead change the require of index.js in /app/build/commands/test262Command.js to a dynamic import() which is available in all CommonJS modules.
2021-09-04T18:20:54.915933+00:00 app[worker.1]:     at Object.<anonymous> (/app/build/commands/test262Command.js:13:38)
2021-09-04T18:20:54.915934+00:00 app[worker.1]:     at Object.<anonymous> (/app/build/commands/index.js:35:14)
2021-09-04T18:20:54.915934+00:00 app[worker.1]:     at Object.<anonymous> (/app/build/commandHandler.js:11:20)
2021-09-04T18:20:54.915935+00:00 app[worker.1]:     at Object.<anonymous> (/app/build/index.js:32:42) {
2021-09-04T18:20:54.915936+00:00 app[worker.1]:   code: 'ERR_REQUIRE_ESM'
2021-09-04T18:20:54.915936+00:00 app[worker.1]: }
```