### PR TITLE
GithubCommand: Adjust closed issue embed color to match github.com

### DIFF
--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -100,7 +100,7 @@ export class GithubCommand extends Command {
             description = description.slice(0, 300) + "...";
         }
 
-        const color = issue.state === "open" ? "#57ab5a" : "#e5534b";
+        const color = issue.state === "open" ? "#57ab5a" : "#6e40c9";
 
         const embed = new MessageEmbed()
             .setColor(color)


### PR DESCRIPTION
The color for closed issues has changed to the same one as merged
pull requests, this patch applies the change to issue embeds.
