### PR TITLE
GithubCommand: Various improvements to embed formatting

### DIFF
--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -116,7 +116,8 @@ export class GithubCommand extends Command {
             .setDescription(description)
             .addField("Type", "Issue", true)
             .addField("Created", `<t:${new Date(issue.created_at).valueOf() / 1000}:R>`, true)
-            .addField("Comments", issue.comments.toString(), true);
+            .addField("Comments", issue.comments.toString(), true)
+            .addField("State", issue.state === "open" ? "Open" : "Closed", true);
 
         const labels = issue.labels
             .map(label => (typeof label === "string" ? label : label.name))
@@ -152,15 +153,25 @@ export class GithubCommand extends Command {
             description = description.slice(0, 300) + "...";
         }
 
+        const state = new Array<string>();
+
         let color: ColorResolvable;
+
+        if (pull.draft) state.push("Draft");
 
         if (pull.merged) {
             color = GitHubColor.Merged;
+
+            state.push("Merged");
         } else if (pull.state === "closed") {
             color = GitHubColor.Closed;
+
+            state.push("Closed");
         } else {
             if (pull.draft) color = GitHubColor.Draft;
             else color = GitHubColor.Open;
+
+            state.push("Open");
         }
 
         const embed = new MessageEmbed()
@@ -171,7 +182,10 @@ export class GithubCommand extends Command {
             .addField("Type", "Pull Request", true)
             .addField("Created", `<t:${new Date(pull.created_at).valueOf() / 1000}:R>`, true)
             .addField("Commits", `${pull.commits} (+${pull.additions} -${pull.deletions})`, true)
-            .addField("Comments", pull.comments.toString(), true);
+            .addField("Comments", pull.comments.toString(), true)
+            // @ts-expect-error Intl.ListFormat is not yet part of the typescript library definitions,
+            //                  see https://github.com/microsoft/TypeScript/issues/46907
+            .addField("State", new Intl.ListFormat().format(state), true);
 
         const labels = pull.labels
             .map(label => label.name)

--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -111,7 +111,7 @@ export class GithubCommand extends Command {
 
         const embed = new MessageEmbed()
             .setColor(color)
-            .setTitle(issue.title)
+            .setTitle(`#${issue.number}: ${issue.title}`)
             .setURL(issue.html_url)
             .setDescription(description)
             .addField("Type", "Issue", true)
@@ -176,7 +176,7 @@ export class GithubCommand extends Command {
 
         const embed = new MessageEmbed()
             .setColor(color)
-            .setTitle(pull.title)
+            .setTitle(`#${pull.number}: ${pull.title}`)
             .setURL(pull.html_url)
             .setDescription(description)
             .addField("Type", "Pull Request", true)

--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -154,12 +154,13 @@ export class GithubCommand extends Command {
 
         let color: ColorResolvable;
 
-        if (pull.draft) {
-            color = GitHubColor.Draft;
-        } else if (pull.merged) {
+        if (pull.merged) {
             color = GitHubColor.Merged;
+        } else if (pull.state === "closed") {
+            color = GitHubColor.Closed;
         } else {
-            color = pull.state === "open" ? GitHubColor.Open : GitHubColor.Closed;
+            if (pull.draft) color = GitHubColor.Draft;
+            else color = GitHubColor.Open;
         }
 
         const embed = new MessageEmbed()

--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -16,6 +16,13 @@ import githubAPI from "../apis/githubAPI";
 import { getSadCaret } from "../util/emoji";
 import Command from "./command";
 
+const enum GitHubColor {
+    Open = "#57ab5a",
+    Closed = "#e5534b",
+    Merged = "#6e40c9",
+    Draft = "#768390",
+}
+
 export class GithubCommand extends Command {
     override data(): ChatInputApplicationCommandData | ChatInputApplicationCommandData[] {
         const options: Array<ApplicationCommandOptionData> = [
@@ -100,7 +107,7 @@ export class GithubCommand extends Command {
             description = description.slice(0, 300) + "...";
         }
 
-        const color = issue.state === "open" ? "#57ab5a" : "#6e40c9";
+        const color = issue.state === "open" ? GitHubColor.Open : GitHubColor.Merged;
 
         const embed = new MessageEmbed()
             .setColor(color)
@@ -148,11 +155,11 @@ export class GithubCommand extends Command {
         let color: ColorResolvable;
 
         if (pull.draft) {
-            color = "#768390";
+            color = GitHubColor.Draft;
         } else if (pull.merged) {
-            color = "#6e40c9";
+            color = GitHubColor.Merged;
         } else {
-            color = pull.state === "open" ? "#57ab5a" : "#e5534b";
+            color = pull.state === "open" ? GitHubColor.Open : GitHubColor.Closed;
         }
 
         const embed = new MessageEmbed()


### PR DESCRIPTION
This pull request improves the appearance of issue and pull request embeds.

Both types of embeds now show their number in the title, a new state field has been added and draft pull requests will only show the draft color when not closed or merged.

Current:

![image](https://user-images.githubusercontent.com/42888162/146444380-67683909-c188-4756-a262-b814a38b0bf2.png)

This branch:

![image](https://user-images.githubusercontent.com/42888162/146444412-a56f23b2-ab80-4792-ad88-9137c36bc580.png)
