### PR TITLE
GithubCommand: Correct regex parsing issue

### DIFF
--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -23,7 +23,7 @@ const enum GitHubColor {
     Draft = "#768390",
 }
 
-const URL_REGEX = /github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+)/g;
+const URL_REGEX = /.+github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+).+/g;
 
 export class GithubCommand extends Command {
     override data(): ChatInputApplicationCommandData | ChatInputApplicationCommandData[] {


### PR DESCRIPTION
This ensures that the url always matches the regex regardless of whats before or after the important part