### PR TITLE
test262Command: Get author name from commit.author if author is null

### DIFF
--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -205,7 +205,11 @@ export class Test262Command extends Command {
             .join("\n");
 
         const embed = new MessageEmbed()
-            .setAuthor(`@${commit.author.login}`, commit.author.avatar_url, commit.author.html_url)
+            .setAuthor({
+                name: commit.author ? commit.author.login : commit.commit.author.name,
+                url: commit.author?.html_url,
+                iconURL: commit.author?.avatar_url,
+            })
             .setTitle(commit.commit.message.split("\n")[0])
             .setDescription(description)
             .setTimestamp(new Date(result.run_timestamp * 1000))


### PR DESCRIPTION
When a commit has an author with no associated GitHub account, commit.author will be null. However, commit.commit.author will at least give you the author name assigned to the commit. We can't get an avatar URL or profile URL from this though, so the command will just display the author name in this case.

![Screenshot from 2022-02-19 01-01-01](https://user-images.githubusercontent.com/25595356/154779564-116a7fba-66e4-4fe8-968e-cf035a9c349d.png)
The first response shows the current state of master, the last two responses show two examples with this fix applied.

Fixes #379 
