### PR TITLE
GithubCommand: Fix regex

### DIFF
--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -23,7 +23,7 @@ const enum GitHubColor {
     Draft = "#768390",
 }
 
-const URL_REGEX = /.+github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+).+/g;
+const URL_REGEX = /.+github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+).*/;
 
 export class GithubCommand extends Command {
     override data(): ChatInputApplicationCommandData | ChatInputApplicationCommandData[] {


### PR DESCRIPTION
I hate regex. The + in .+ actually means make sure this takes a character even if it takes it from something else, and the /g doesn't work because :shrug: