### PR TITLE
test262Command: Assortment of improvements

### DIFF
--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -269,7 +269,20 @@ export class Test262Command extends Command {
                 }
             }
 
-            embed.addField(`${name} (${test.duration.toFixed(2)}s)`, fields.join(" | "), false);
+            const previousDuration = previousTest?.duration ?? 0;
+            const durationLabel = `${test.duration.toFixed(2)}s`;
+            if (previousDuration - test.duration !== 0) {
+                const difference = test.duration - previousDuration;
+                const differenceSign = difference > 0 ? "+" : "";
+                const differenceLabel = `${differenceSign}${difference.toFixed(2)}s`;
+                embed.addField(
+                    `${name} (${durationLabel}) (${differenceLabel})`,
+                    fields.join(" | "),
+                    false
+                );
+            } else {
+                embed.addField(`${name} (${durationLabel})`, fields.join(" | "), false);
+            }
         }
 
         return embed;

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -20,6 +20,7 @@ import {
     getPoggie,
     getSadCaret,
     getSkeleyak,
+    getYak,
     getYakslice,
     getYaksplode,
     getYakstack,
@@ -153,7 +154,7 @@ export class Test262Command extends Command {
             case "passed":
                 return (await getPoggie(client))?.toString() ?? label;
             case "failed":
-                return "🦬";
+                return (await getYak(client))?.toString() ?? label;
             case "skipped":
                 return (await getBuggiemagnify(client))?.toString() ?? label;
             case "metadata_error":

--- a/src/commands/test262Command.ts
+++ b/src/commands/test262Command.ts
@@ -169,6 +169,8 @@ export class Test262Command extends Command {
                 return (await getNeoyak(client))?.toString() ?? label;
             case "todo_error":
                 return (await getYakstack(client))?.toString() ?? label;
+            case "percentage_passing":
+                return (await getLibjs(client))?.toString() ?? label;
             default:
                 return label;
         }
@@ -227,14 +229,19 @@ export class Test262Command extends Command {
                 : 0;
             const percentageDifference = (percentage - previousPercentage).toFixed(2);
 
+            const libjsEmoji = await Test262Command.statusIconForLabel(
+                client,
+                "percentage_passing"
+            );
+
             if (percentageDifference !== "0.00" && percentageDifference !== "-0.00") {
                 fields.push(
-                    `${(await getLibjs(client))?.toString()} ${percentage.toFixed(2)}% (${
+                    `${libjsEmoji} ${percentage.toFixed(2)}% (${
                         percentageDifference.startsWith("-") ? "" : "+"
                     }${percentageDifference}) `
                 );
             } else {
-                fields.push(`${(await getLibjs(client))?.toString()} ${percentage.toFixed(2)}%`);
+                fields.push(`${libjsEmoji} ${percentage.toFixed(2)}%`);
             }
 
             for (const [label, value] of Object.entries(test.results)) {

--- a/src/util/emoji.ts
+++ b/src/util/emoji.ts
@@ -126,3 +126,8 @@ export async function getClosedPull(clientOrParent: ClientOrParent): Promise<Emo
 export async function getMergedPull(clientOrParent: ClientOrParent): Promise<Emoji | null> {
     return await getEmoji(clientOrParent, "merged_pull");
 }
+
+/** Alias function for the :yak: emoji */
+export async function getYak(clientOrParent: ClientOrParent): Promise<Emoji | null> {
+    return await getEmoji(clientOrParent, "yak");
+}


### PR DESCRIPTION
test262Command: Use :yak: emoji instead of the Unicode bison emoji

Andreas added this emoji to the server so that we can have a
consistent yak emoji across all platforms, so lets use it for the
test262 command as well :^).

-----

test262Command: Say "percentage_passing" if the test262 emoji is missing

Previously it would say "undefined".

-----

test262Command: Show test duration differences

![Screenshot from 2022-03-07 14-48-10](https://user-images.githubusercontent.com/25595356/157065740-aa18be6d-bfca-48c5-9ad0-213b989f19d8.png)