### PR TITLE
ManCommand: Add man.serenityos.org as an option for navigation

### DIFF
--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -56,11 +56,11 @@ export class ManCommand extends Command {
         const result = await githubAPI.fetchSerenityManpage(section, page);
 
         if (result) {
-            const { markdown, url } = result;
+            const { markdown, url: githubUrl } = result;
 
             await interaction.reply({
                 fetchReply: true,
-                embeds: [ManCommand.embedForMan(markdown, url, section, page, true)],
+                embeds: [ManCommand.embedForMan(markdown, githubUrl, section, page, true)],
                 components: [await ManCommand.buttons(interaction)],
             });
         } else {
@@ -96,10 +96,10 @@ export class ManCommand extends Command {
 
             if (result == null) return;
 
-            const { markdown, url, page, section } = result;
+            const { markdown, url: githubUrl, page, section } = result;
 
             interaction.update({
-                embeds: [ManCommand.embedForMan(markdown, url, section, page, collapsed)],
+                embeds: [ManCommand.embedForMan(markdown, githubUrl, section, page, collapsed)],
             });
         }
     }
@@ -126,7 +126,7 @@ export class ManCommand extends Command {
 
     static embedForMan(
         markdown: string,
-        url: string,
+        githubUrl: string,
         section: string,
         page: string,
         collapsed: boolean
@@ -141,7 +141,7 @@ export class ManCommand extends Command {
             if (line.startsWith("## ")) {
                 if (currentParagraph.content !== "") {
                     if (currentParagraph.title === "Name") {
-                        name = currentParagraph.content;
+                        name = currentParagraph.content.replace(/[\r\n]/g, "");
                     } else {
                         paragraphs.push(currentParagraph);
                     }
@@ -163,10 +163,16 @@ export class ManCommand extends Command {
             }
         }
 
+        const url = `https://man.serenityos.org/man${section}/${page}.html`;
+
         const embed = new MessageEmbed()
             .setTitle(`${page}(${section})`)
-            .setDescription(name ?? "Name not found")
-            .setURL(`https://man.serenityos.org/man${section}/${page}.html`)
+            .setDescription(
+                `${
+                    name ?? "Name not found"
+                }\n\n[View on GitHub](${githubUrl}) - [View on man.serenityos.org](${url})`
+            )
+            .setURL(url)
             .setTimestamp();
 
         for (const paragraph of paragraphs)

--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -166,7 +166,7 @@ export class ManCommand extends Command {
         const embed = new MessageEmbed()
             .setTitle(`${page}(${section})`)
             .setDescription(name ?? "Name not found")
-            .setURL(url)
+            .setURL(`https://man.serenityos.org/man${section}/${page}.html`)
             .setTimestamp();
 
         for (const paragraph of paragraphs)


### PR DESCRIPTION
This pull request makes use of man.serenityos.org as the default title link and adds an explicit link to GitHub as well as serenityos.org to the embed description.

![image](https://user-images.githubusercontent.com/42888162/163052023-3eff6072-d66b-488e-a79c-fb2aa184f394.png)
