### PR TITLE
GithubCommand: Allow specifiying a different repository 

### DIFF
--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -25,9 +25,13 @@ export interface Fortune {
     context?: string;
 }
 
-type PromiseResolvedType<T> = T extends Promise<infer R> ? R : never; // from https://timm.preetz.name/articles/typescript-async-function-return-value
+export interface Repository {
+    owner: string;
+    name: string;
+}
+
 type SearchResultReturnType = Exclude<
-    PromiseResolvedType<ReturnType<Octokit["search"]["issuesAndPullRequests"]>>["data"]["items"],
+    Awaited<ReturnType<Octokit["search"]["issuesAndPullRequests"]>>["data"]["items"],
     number
 >;
 

--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2021-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,13 +8,44 @@ import {
     ApplicationCommandOptionData,
     ChatInputApplicationCommandData,
     CommandInteraction,
+    TextChannel,
 } from "discord.js";
-import githubAPI from "../apis/githubAPI";
+import githubAPI, { Repository, SERENITY_REPOSITORY } from "../apis/githubAPI";
 import { embedFromIssueOrPull } from "../util/embedFromIssueOrPull";
 import { getSadCaret } from "../util/emoji";
 import Command from "./command";
 
-const URL_REGEX = /.+github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+).*/;
+const repositories: Array<{
+    name: string;
+    urlRegex: RegExp;
+    repository: Repository;
+    defaultCategories: Array<string>;
+}> = [
+    {
+        name: "serenity",
+        repository: SERENITY_REPOSITORY,
+        urlRegex: /.+github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+).*/,
+        defaultCategories: [
+            // DEVELOPMENT
+            "830526756619288616",
+
+            // SUPPORT
+            "836187014617104394",
+        ],
+    },
+    {
+        name: "jakt",
+        repository: {
+            owner: "SerenityOS",
+            name: "jakt",
+        },
+        urlRegex: /.+github.com\/SerenityOS\/jakt\/(?:issues|pull)\/(\d+).*/,
+        defaultCategories: [
+            // JAKT
+            "976984132376744027",
+        ],
+    },
+];
 
 export class GithubCommand extends Command {
     override data(): ChatInputApplicationCommandData | ChatInputApplicationCommandData[] {
@@ -33,6 +64,12 @@ export class GithubCommand extends Command {
                 name: "url",
                 description: "The full url to an issue or pull request",
                 type: "STRING",
+            },
+            {
+                name: "repository",
+                description: "The repository to query in",
+                type: "STRING",
+                choices: Object.values(repositories).map(({ name }) => ({ name, value: name })),
             },
         ];
 
@@ -58,28 +95,62 @@ export class GithubCommand extends Command {
     }
 
     override async handleCommand(interaction: CommandInteraction): Promise<void> {
+        const url = interaction.options.getString("url");
+        const repositoryName = interaction.options.getString("repository");
         const number = interaction.options.getNumber("number");
         const query = interaction.options.getString("query");
-        const url = interaction.options.getString("url");
+
+        // When a url was specified, try all known regexes to find the referenced repository and issue / pull id
+        if (url) {
+            for (const { repository, urlRegex } of repositories) {
+                const matches = url.match(urlRegex);
+
+                if (matches !== null) {
+                    const number = parseInt(matches[1]);
+                    const result = await embedFromIssueOrPull(
+                        await githubAPI.getIssueOrPull(number, repository)
+                    );
+
+                    if (result) return await interaction.reply({ embeds: [result] });
+                }
+            }
+        }
+
+        let repository: Repository | undefined;
+
+        // If a repository name was provided explicitly, find the repository associated with it
+        if (repositoryName !== null) {
+            repository = repositories.find(
+                repository => repository.name === repositoryName
+            )?.repository;
+        }
+
+        // If no repository name was provided, try to use the channel category to infer a repository
+        if (repository === undefined) {
+            const categoryId = await interaction.channel
+                ?.fetch()
+                .then(channel => (channel instanceof TextChannel ? channel.parentId : undefined));
+
+            repository = repositories.find(repo =>
+                repo.defaultCategories.includes(categoryId as string)
+            )?.repository;
+        }
+
+        // Fall back to the serenity repository
+        repository ??= SERENITY_REPOSITORY;
 
         if (number !== null) {
-            const result = await embedFromIssueOrPull(await githubAPI.getIssueOrPull(number));
+            const result = await embedFromIssueOrPull(
+                await githubAPI.getIssueOrPull(number, repository)
+            );
 
             if (result) return await interaction.reply({ embeds: [result] });
         }
 
-        if (url && URL_REGEX.test(url)) {
-            const matches = url.match(URL_REGEX);
-            if (matches !== null && matches[1]) {
-                const number = parseInt(matches[1]);
-                const result = await embedFromIssueOrPull(await githubAPI.getIssueOrPull(number));
-
-                if (result) return await interaction.reply({ embeds: [result] });
-            }
-        }
-
         if (query) {
-            const result = await embedFromIssueOrPull(await githubAPI.searchIssuesOrPulls(query));
+            const result = await embedFromIssueOrPull(
+                await githubAPI.searchIssuesOrPulls(query, repository)
+            );
 
             if (result) return await interaction.reply({ embeds: [result] });
         }

--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -14,7 +14,7 @@ import {
     MessageReference,
     User,
 } from "discord.js";
-import githubAPI from "../apis/githubAPI";
+import githubAPI, { SERENITY_REPOSITORY } from "../apis/githubAPI";
 import { QUOTE_ROLE_ID } from "../config/secrets";
 import { getSadCaret } from "../util/emoji";
 import Command from "./command";
@@ -102,7 +102,7 @@ export class QuoteCommand extends Command {
         }
 
         await interaction.reply(
-            `Pull Request opened! https://github.com/${githubAPI.repository}/pull/${pullRequestNumber}`
+            `Pull Request opened! https://github.com/${SERENITY_REPOSITORY.owner}/${SERENITY_REPOSITORY.name}/pull/${pullRequestNumber}`
         );
     }
 

--- a/src/util/embedFromIssueOrPull.ts
+++ b/src/util/embedFromIssueOrPull.ts
@@ -26,8 +26,16 @@ export async function embedFromIssueOrPull(
 ): Promise<MessageEmbed | undefined> {
     if (!issueOrPull) return undefined;
 
+    // FIXME: We already had this information in a nice format when fetching
+    //        issueOrPull, find a way to include that object in the argument.
+    const parts = issueOrPull.repository_url.split("/").reverse();
+    const repository = {
+        owner: parts[1],
+        name: parts[0],
+    };
+
     if (issueOrPull.pull_request) {
-        const pull = await GithubAPI.getPull(issueOrPull.number);
+        const pull = await GithubAPI.getPull(issueOrPull.number, repository);
 
         if (pull) return embedFromPull(pull);
     }

--- a/src/util/embedFromIssueOrPull.ts
+++ b/src/util/embedFromIssueOrPull.ts
@@ -11,7 +11,7 @@ import {
     InteractionReplyOptions,
     MessageEmbed,
 } from "discord.js";
-import GithubAPI from "../apis/githubAPI";
+import GithubAPI, { Repository } from "../apis/githubAPI";
 import { getSadCaret } from "./emoji";
 
 export const enum GitHubColor {
@@ -37,14 +37,15 @@ export async function embedFromIssueOrPull(
     if (issueOrPull.pull_request) {
         const pull = await GithubAPI.getPull(issueOrPull.number, repository);
 
-        if (pull) return embedFromPull(pull);
+        if (pull) return embedFromPull(pull, repository);
     }
 
-    return embedFromIssue(issueOrPull);
+    return embedFromIssue(issueOrPull, repository);
 }
 
 export function embedFromIssue(
-    issue: RestEndpointMethodTypes["issues"]["get"]["response"]["data"]
+    issue: RestEndpointMethodTypes["issues"]["get"]["response"]["data"],
+    repository: Repository
 ): MessageEmbed {
     let description = issue.body || "";
     if (description.length > 300) {
@@ -55,7 +56,7 @@ export function embedFromIssue(
 
     const embed = new MessageEmbed()
         .setColor(color)
-        .setTitle(`#${issue.number}: ${issue.title}`)
+        .setTitle(`${repository.name} #${issue.number}: ${issue.title}`)
         .setURL(issue.html_url)
         .setDescription(description)
         .addField("Type", "Issue", true)
@@ -94,7 +95,8 @@ export function embedFromIssue(
 }
 
 export function embedFromPull(
-    pull: RestEndpointMethodTypes["pulls"]["get"]["response"]["data"]
+    pull: RestEndpointMethodTypes["pulls"]["get"]["response"]["data"],
+    repository: Repository
 ): MessageEmbed {
     let description = pull.body || "";
     if (description.length > 300) {
@@ -124,7 +126,7 @@ export function embedFromPull(
 
     const embed = new MessageEmbed()
         .setColor(color)
-        .setTitle(`#${pull.number}: ${pull.title}`)
+        .setTitle(`${repository.name} #${pull.number}: ${pull.title}`)
         .setURL(pull.html_url)
         .setDescription(description)
         .addField("Type", "Pull Request", true)

--- a/tests/githubAPI.test.ts
+++ b/tests/githubAPI.test.ts
@@ -1,4 +1,4 @@
-import githubAPI from "../src/apis/githubAPI";
+import githubAPI, { SERENITY_REPOSITORY } from "../src/apis/githubAPI";
 import { GITHUB_TOKEN } from "../src/config/secrets";
 import { assert } from "chai";
 
@@ -14,7 +14,7 @@ describe("githubApi", function () {
         // The test  if the environment is configured for serenity, or
         // if we don't have a github API token setup.
         assert.isFalse(
-            githubAPI.repository.startsWith("SerenityOS"),
+            SERENITY_REPOSITORY.owner === "SerenityOS",
             "We should never run this test against the real repo."
         );
         assert.isDefined(GITHUB_TOKEN, "We need a valid configured github token to run this test.");


### PR DESCRIPTION
This pull request adds a new option to the github commands, allowing users to specify which repository they want to query.

Currently `serenity` and `jakt` are supported.

The repository gets inferred automatically based on the channel category the command got run in

![image](https://user-images.githubusercontent.com/42888162/169672549-415b1602-a1a3-4ef2-b376-c111b7cdb11c.png)
