### PR TITLE
Index: Remove embeds from github.com

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,5 +49,26 @@ client.on("interactionCreate", async (interaction: Interaction) => {
 client.on("error", e => {
     console.error("Discord client error!", e);
 });
+client.on("message", message => {
+    if (message.author.bot) return;
+
+    for (const embed of message.embeds) {
+        if (!embed.url) continue;
+
+        const url = new URL(embed.url);
+        if (url.host !== "github.com") continue;
+
+        // eg.: embed.url: "https://github.com/SerenityOS/serenity/blob/master/AK/AllOf.h"
+        //      url.pathname: "/SerenityOS/serenity/blob/master/AK/AllOf.h"
+        //      segments: ["", "SerenityOS", "serenity", "blob", "master", "AK", "AllOf.h"]
+        //      githubUrlType: "blob"
+        const segments = url.pathname.split("/");
+        const githubUrlType: string | undefined = segments[3];
+        if (githubUrlType === "tree" || githubUrlType === "blob") {
+            message.suppressEmbeds();
+            return;
+        }
+    }
+});
 
 client.login(DISCORD_TOKEN);


### PR DESCRIPTION
Repository embeds from discord fill up a lot of screen space without providing much relevant information.
    
This pull request adds a message listener that removes the embeds on a message automatically if the message has an embed from `github.com` with `blob` or `tree` being the third segment in the pathname (the type of github url). Sadly the api does not allow more fine grain removal of a single embed, however multiple embeds in a single message are quite rare.

As requested by linusg on discord: https://discord.com/channels/830522505605283862/830739873119207426/986007342443282493