### PR TITLE
Fix the quote command

### DIFF
--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -162,13 +162,14 @@ class GithubAPI {
 
     async openFortunesPullRequest(
         fortunes: Fortune[],
-        triggeredBy: string
+        triggeredBy: string,
+        fortuneAuthor: string
     ): Promise<number | undefined> {
         const json = JSON.stringify(fortunes, null, 2);
         const result = await composeCreatePullRequest(this.octokit, {
             owner: SERENITY_REPOSITORY.owner,
             repo: SERENITY_REPOSITORY.name,
-            title: "Base: Add a quote to the fortunes database",
+            title: `Base: Add a quote from ${fortuneAuthor} to the fortunes database`,
             body: `Triggered by ${triggeredBy} on Discord.`,
             head: `add-quote-${Math.floor(Date.now() / 1000)}`,
             changes: [

--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -93,7 +93,8 @@ export class QuoteCommand extends Command {
         const commandIssuerNick = await this.getAuthorNick(guild, interaction.user);
         const pullRequestNumber = await githubAPI.openFortunesPullRequest(
             fortunes,
-            commandIssuerNick
+            commandIssuerNick,
+            nickname
         );
 
         if (pullRequestNumber == undefined) {

--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -68,6 +68,10 @@ export class QuoteCommand extends Command {
             });
         }
 
+        // Accessing GitHub APIs for PR creation can easily exceed 3s.
+        // After that, the interaction ID is gone if we don't defer the reply.
+        await interaction.deferReply();
+
         const guildId: string = messageReference.guildId;
         const guild = await this.getGuild(interaction.client, guildId);
         if (!guild) return;
@@ -95,13 +99,11 @@ export class QuoteCommand extends Command {
         if (pullRequestNumber == undefined) {
             const sadcaret = await getSadCaret(interaction);
 
-            return await interaction.reply({
-                content: `Failed creating a pull request ${sadcaret ?? ":^("}`,
-                ephemeral: true,
-            });
+            await interaction.editReply(`Failed creating a pull request ${sadcaret ?? ":^("}`);
+            return;
         }
 
-        await interaction.reply(
+        await interaction.editReply(
             `Pull Request opened! https://github.com/${SERENITY_REPOSITORY.owner}/${SERENITY_REPOSITORY.name}/pull/${pullRequestNumber}`
         );
     }

--- a/tests/githubAPI.test.ts
+++ b/tests/githubAPI.test.ts
@@ -31,7 +31,8 @@ describe("githubApi", function () {
         const commandIssuerNick = "Unit Test Executor";
         const pullRequestNumber = await githubAPI.openFortunesPullRequest(
             fortunes,
-            commandIssuerNick
+            commandIssuerNick,
+            "unit tests"
         );
 
         assert.isDefined(


### PR DESCRIPTION
That has been broken for a while, the reason comes down to Discord interaction restrictions.

Also a small fix to include quoted username in created PRs, which I find more transparent.

Fixes #356 