### PR TITLE
Index: Add unhandledRejection handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ import CommandHandler from "./commandHandler";
 import config from "./config/botConfig";
 import { DISCORD_TOKEN } from "./config/secrets";
 
+process.on("unhandledRejection", reason => {
+    console.log("Unhandled Rejection:", reason);
+});
+
 const client = new Discord.Client({
     intents: [
         Intents.FLAGS.GUILDS,


### PR DESCRIPTION
This pull request adds a global handler for rejected promises to avoid crashes. As discussed in https://discord.com/channels/830522505605283862/830739873119207426/988858862088097873

The output would look something like
![image](https://user-images.githubusercontent.com/42888162/174864599-4b7efe12-196a-4bca-8dbc-18a9b83dbfdf.png)
