### PR TITLE
Meta: Allow usage of node version from 16 up to 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,72 +1,72 @@
 {
-  "name": "buggie-bot",
-  "version": "0.0.1",
-  "description": "SerenityOS Discord Bot",
-  "main": "index.js",
-  "license": "BSD-2-Clause",
-  "engines": {
-    "node": "=>16.x"
-  },
-  "scripts": {
-    "lint": "eslint . --ext .ts",
-    "lint-and-fix": "eslint . --ext .ts --fix",
-    "prestart:dev": "npm run build",
-    "start:dev": "nodemon build/index.js",
-    "prebuild": "rimraf ./build",
-    "build": "tsc",
-    "prestart": "npm run build",
-    "start": "node build/index.js",
-    "test": "mocha -r ts-node/register tests/**/*.test.ts"
-  },
-  "nodemonConfig": {
-    "watch": [
-      "src"
+    "name": "buggie-bot",
+    "version": "0.0.1",
+    "description": "SerenityOS Discord Bot",
+    "main": "index.js",
+    "license": "BSD-2-Clause",
+    "engines": {
+        "node": ">=16 <=19"
+    },
+    "scripts": {
+        "lint": "eslint . --ext .ts",
+        "lint-and-fix": "eslint . --ext .ts --fix",
+        "prestart:dev": "npm run build",
+        "start:dev": "nodemon build/index.js",
+        "prebuild": "rimraf ./build",
+        "build": "tsc",
+        "prestart": "npm run build",
+        "start": "node build/index.js",
+        "test": "mocha -r ts-node/register tests/**/*.test.ts"
+    },
+    "nodemonConfig": {
+        "watch": [
+            "src"
+        ],
+        "ext": ".ts,.js",
+        "ignore": [],
+        "exec": "ts-node ./src/index.ts"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/SerenityOS/discord-bot.git"
+    },
+    "keywords": [
+        "discord",
+        "typescript",
+        "bot",
+        "serenityos"
     ],
-    "ext": ".ts,.js",
-    "ignore": [],
-    "exec": "ts-node ./src/index.ts"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/SerenityOS/discord-bot.git"
-  },
-  "keywords": [
-    "discord",
-    "typescript",
-    "bot",
-    "serenityos"
-  ],
-  "bugs": {
-    "url": "https://github.com/SerenityOS/discord-bot/issues"
-  },
-  "homepage": "https://github.com/SerenityOS/discord-bot#readme",
-  "devDependencies": {
-    "@octokit/types": "^8.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.42.0",
-    "@typescript-eslint/parser": "^5.41.0",
-    "eslint": "^8.26.0",
-    "@types/chai": "^4.3.3",
-    "@types/mocha": "^10.0.0",
-    "chai": "^4.3.6",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-unused-imports": "^2.0.0",
-    "mocha": "^10.1.0",
-    "nodemon": "^2.0.20",
-    "prettier": "^2.7.1",
-    "ts-node": "^10.9.1"
-  },
-  "dependencies": {
-    "@octokit/rest": "^19.0.4",
-    "@types/node": "^18.11.7",
-    "axios": "^1.1.3",
-    "bufferutil": "^4.0.7",
-    "discord.js": "^13.8.1",
-    "dotenv": "^16.0.3",
-    "octokit-plugin-create-pull-request": "^4.0.0",
-    "rimraf": "^3.0.2",
-    "typescript": "^4.8.4",
-    "utf-8-validate": "^5.0.10",
-    "zlib-sync": "^0.1.7"
-  }
+    "bugs": {
+        "url": "https://github.com/SerenityOS/discord-bot/issues"
+    },
+    "homepage": "https://github.com/SerenityOS/discord-bot#readme",
+    "devDependencies": {
+        "@octokit/types": "^8.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.42.0",
+        "@typescript-eslint/parser": "^5.41.0",
+        "eslint": "^8.26.0",
+        "@types/chai": "^4.3.3",
+        "@types/mocha": "^10.0.0",
+        "chai": "^4.3.6",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-unused-imports": "^2.0.0",
+        "mocha": "^10.1.0",
+        "nodemon": "^2.0.20",
+        "prettier": "^2.7.1",
+        "ts-node": "^10.9.1"
+    },
+    "dependencies": {
+        "@octokit/rest": "^19.0.4",
+        "@types/node": "^18.11.7",
+        "axios": "^1.1.3",
+        "bufferutil": "^4.0.7",
+        "discord.js": "^13.8.1",
+        "dotenv": "^16.0.3",
+        "octokit-plugin-create-pull-request": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.8.4",
+        "utf-8-validate": "^5.0.10",
+        "zlib-sync": "^0.1.7"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "BSD-2-Clause",
   "engines": {
-    "node": "16.x"
+    "node": "=>16.x"
   },
   "scripts": {
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
There have been zero breaking changes since node 16 that affects us,
so, allow maintainers to use the latest LTS in development and let the
`CI` workflow be a safeguard for those rare instances where somebody
might accidentally use a newer unsupported feature (most of which would
be handled by the typescript transpiler anyways).