### PR TITLE
Util+Everywhere: Logging & Logging Managment

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     },
     "dependencies": {
         "@octokit/plugin-throttling": "^4.3.2",
+        "@discordjs/builders": "^1.3.0",
         "@octokit/rest": "^19.0.4",
         "@types/node": "^18.11.9",
         "axios": "^1.1.3",

--- a/src/apis/githubAPI.ts
+++ b/src/apis/githubAPI.ts
@@ -11,6 +11,7 @@ import { Octokit } from "@octokit/rest";
 import { throttling as OctokitThrottling } from "@octokit/plugin-throttling";
 import { composeCreatePullRequest } from "octokit-plugin-create-pull-request";
 import config from "../config/botConfig";
+import logger from "../util/logger";
 
 export interface ManPage {
     url: string;
@@ -94,8 +95,8 @@ class GithubAPI {
                 issue_number: number,
             });
             return results.data;
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return undefined;
         }
     }
@@ -108,8 +109,8 @@ class GithubAPI {
                 pull_number: number,
             });
             return results.data;
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return undefined;
         }
     }
@@ -137,7 +138,7 @@ class GithubAPI {
         } catch (e: any) {
             if (e.status === 404) return null;
 
-            console.trace(e);
+            logger.trace(e);
             throw e;
         }
     }
@@ -157,7 +158,7 @@ class GithubAPI {
             });
 
             return results.data?.total_count;
-        } catch (e: any) {
+        } catch (e) {
             console.trace(e);
             throw e;
         }
@@ -187,8 +188,8 @@ class GithubAPI {
                 }
             );
             return results.data;
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return undefined;
         }
     }
@@ -224,8 +225,8 @@ class GithubAPI {
                 page,
                 markdown,
             };
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return;
         }
     }
@@ -259,7 +260,7 @@ class GithubAPI {
             ],
         });
         if (result == null) {
-            console.trace("Failed to create pull request");
+            logger.error("Failed to create pull request");
             return;
         }
         return result.data.number;

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -21,15 +21,17 @@ import {
     Test262Command,
     UserCommand,
 } from "./commands";
+
 import Command from "./commands/command";
-import config from "./config/botConfig";
 import { GUILD_ID } from "./config/secrets";
+import config from "./config/botConfig";
+import logger from "./util/logger";
 
 export default class CommandHandler {
     private readonly commands: Map<string[], Command>;
     private readonly help: string;
 
-    constructor(private readonly production: boolean) {
+    constructor() {
         const commandClasses = [
             CommitStatsCommand,
             ManCommand,
@@ -86,14 +88,6 @@ export default class CommandHandler {
 
     /** Executes user commands contained in a message if appropriate. */
     async handleBaseCommandInteraction(interaction: BaseCommandInteraction): Promise<void> {
-        if (!this.production) {
-            const msg = `Buggie bot received '${JSON.stringify(interaction, (_, v) =>
-                typeof v === "bigint" ? `${v.toString()}n` : v
-            )} from '${interaction.user.tag}`;
-            await interaction.channel?.send(msg);
-            await console.log(msg);
-        }
-
         if (interaction.commandName === "help") {
             return await interaction.reply({
                 ephemeral: true,
@@ -183,7 +177,7 @@ export default class CommandHandler {
         interaction: T & { reply: BaseCommandInteraction["reply"] }
     ): Promise<void> {
         await handler.call(command, interaction).catch(error => {
-            console.trace("matchedCommand.handle{Select|Context}Menu failed", error);
+            logger.trace("matchedCommand.handle{Select|Context}Menu failed", error);
             interaction.reply({ ephemeral: true, content: `Failed because of ${error}` });
         });
     }

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -14,6 +14,7 @@ import {
     CommitStatsCommand,
     EmojiCommand,
     GithubCommand,
+    LogCommand,
     ManCommand,
     PlanCommand,
     QuickLinksCommand,
@@ -42,6 +43,7 @@ export default class CommandHandler {
             EmojiCommand,
             QuoteCommand,
             UserCommand,
+            LogCommand,
         ];
 
         const availableCommands = new Array<string>();
@@ -112,12 +114,17 @@ export default class CommandHandler {
                 content: "I don't recognize that command.",
             });
 
-        if (interaction.isCommand())
+        if (interaction.isCommand()) {
+            logger.silly(
+                `${interaction.user.tag} is executing ${interaction.commandName}`,
+                interaction.options
+            );
             return this.callInteractionHandler(
                 matchedCommand,
                 matchedCommand.handleCommand,
                 interaction
             );
+        }
 
         if (interaction.isContextMenu() && matchedCommand.handleContextMenu)
             return this.callInteractionHandler(
@@ -177,7 +184,7 @@ export default class CommandHandler {
         interaction: T & { reply: BaseCommandInteraction["reply"] }
     ): Promise<void> {
         await handler.call(command, interaction).catch(error => {
-            logger.trace("matchedCommand.handle{Select|Context}Menu failed", error);
+            logger.trace(error);
             interaction.reply({ ephemeral: true, content: `Failed because of ${error}` });
         });
     }

--- a/src/commands/commitStatsCommand.ts
+++ b/src/commands/commitStatsCommand.ts
@@ -10,6 +10,7 @@ import {
     CommandInteraction,
 } from "discord.js";
 import githubAPI, { Commit, Repository } from "../apis/githubAPI";
+import logger from "../util/logger";
 import Command from "./command";
 
 export class CommitStatsCommand extends Command {
@@ -205,7 +206,7 @@ export class CommitStatsCommand extends Command {
                 });
             }
         } catch (e) {
-            console.trace(e);
+            logger.trace(e);
             await interaction.editReply({
                 content: `Something went really wrong :^(\n\n\`\`\`${
                     (e as Error)?.stack ?? e ?? ""

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -26,3 +26,4 @@ export * from "./test262Command";
 export * from "./emojiCommand";
 export * from "./quoteCommand";
 export * from "./userCommand";
+export * from "./logCommand";

--- a/src/commands/logCommand.ts
+++ b/src/commands/logCommand.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { ApplicationCommandData, CommandInteraction } from "discord.js";
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { LogLevel } from "../util/logger";
+import logger from "../util/logger";
+import Command from "./command";
+import { PRIVILEGED_GROUP_IDS } from "../config/secrets";
+import config from "../config/botConfig";
+
+export class LogCommand extends Command {
+    override data(): ApplicationCommandData | ApplicationCommandData[] {
+        const command = new SlashCommandBuilder()
+            .setName("log")
+            .setDescription("Manage BuggieBot's logging")
+            .addSubcommand(command =>
+                command.setName("get").setDescription("Get the current logging value")
+            )
+            .addSubcommand(command =>
+                command
+                    .setName("set")
+                    .setDescription("Temporarily set the logging level")
+                    .addNumberOption(level =>
+                        level
+                            .setName("level")
+                            .setDescription("The logging level")
+                            .setRequired(true)
+                            .setChoices(
+                                ...Object.keys(LogLevel)
+                                    .filter(v => isNaN(Number(v)))
+                                    .map((level, index) => ({
+                                        name: level,
+                                        value: index,
+                                    }))
+                            )
+                    )
+            );
+
+        return command.toJSON() as any;
+    }
+
+    private async noPermission(interaction: CommandInteraction): Promise<void> {
+        return await interaction.reply({ ephemeral: true, content: "Insufficient permission" });
+    }
+
+    override async handleCommand(interaction: CommandInteraction): Promise<void> {
+        if (!interaction.isCommand()) return;
+
+        const issuer = await interaction.guild?.members?.fetch(interaction.user);
+        if (!issuer)
+            return await interaction.reply({
+                ephemeral: true,
+                content: "Command only available on the SerenityOS Discord Server",
+            });
+
+        const isPrivileged = issuer.roles.cache.hasAny(...PRIVILEGED_GROUP_IDS);
+        const subcommand: "get" | "set" = interaction.options.getSubcommand() as any;
+
+        switch (subcommand) {
+            case "get": {
+                const modified = logger.level !== config.logLevel;
+
+                await interaction.reply({
+                    content: `The logging level is currently set to ${modified ? "**" : ""}\`${
+                        LogLevel[logger.level]
+                    }\`${modified ? " (modified)**" : ""}!`,
+                });
+                return;
+            }
+            case "set": {
+                if (!isPrivileged) return await this.noPermission(interaction);
+
+                const level = interaction.options.getNumber("level", true);
+                const previous = logger.level;
+
+                logger.setLevel(level);
+
+                await interaction.reply({
+                    content: `The logging level was successfully changed from \`${LogLevel[previous]}\` to \`${LogLevel[level]}\``,
+                });
+                return;
+            }
+            default: {
+                await interaction.reply({
+                    ephemeral: true,
+                    content: "Invalid subcommand",
+                });
+                return;
+            }
+        }
+    }
+}

--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -17,6 +17,7 @@ import {
 import githubAPI, { SERENITY_REPOSITORY } from "../apis/githubAPI";
 import { QUOTE_ROLE_ID } from "../config/secrets";
 import { getSadCaret } from "../util/emoji";
+import logger from "../util/logger";
 import Command from "./command";
 
 export class QuoteCommand extends Command {
@@ -162,8 +163,8 @@ export class QuoteCommand extends Command {
                 channelId: message.channel.id,
                 messageId: message.id,
             };
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return;
         }
     }
@@ -177,8 +178,8 @@ export class QuoteCommand extends Command {
             const channel = guild.channels.resolve(messageReference.channelId);
             if (channel == null || !channel.isText()) return;
             return await channel.messages.fetch(messageReference.messageId);
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return;
         }
     }
@@ -186,8 +187,8 @@ export class QuoteCommand extends Command {
     private async getGuild(client: Client, guildId: string): Promise<Guild | undefined> {
         try {
             return await client.guilds.fetch(guildId);
-        } catch (e) {
-            console.trace(e);
+        } catch (e: any) {
+            logger.trace(e);
             return;
         }
     }

--- a/src/config/botConfig.ts
+++ b/src/config/botConfig.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import type { LogLevel } from "../util/logger";
+
 type BotConfig = {
     production: boolean;
     excludedRepositories: string[];
+    logLevel: LogLevel;
 };
 
 const config: BotConfig = {
@@ -18,6 +21,7 @@ const config: BotConfig = {
         "artwork",
         "manpages-website",
     ],
+    logLevel: process.env.log_level ? Number.parseInt(process.env.log_level, 10) : 5,
 };
 
 export default config;

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -5,6 +5,7 @@
  */
 
 import dotenv from "dotenv";
+import logger from "../util/logger";
 
 dotenv.config({ path: ".env" });
 
@@ -12,24 +13,31 @@ export const DISCORD_TOKEN = process.env["discord_token"];
 export const GITHUB_TOKEN = process.env["github_token"];
 export let GUILD_ID = process.env["guild_id"];
 export let QUOTE_ROLE_ID = process.env["quote_role_id"];
+export const LOG_CHANNEL_ID = process.env["log_channel_id"];
 
 if (!DISCORD_TOKEN) {
-    console.error("No 'discord_token' provided in .env file.");
+    logger.error("No 'discord_token' provided in .env file.");
 }
 if (!GITHUB_TOKEN) {
-    console.error(
+    logger.error(
         "No 'github_token' provided in .env file, the rate limit will be greatly reduced!"
     );
 }
 if (!GUILD_ID) {
-    console.warn("No 'guild_id' provided in .env file, using id of the SerenityOS guild.");
+    logger.warn("No 'guild_id' provided in .env file, using id of the SerenityOS guild.");
 
     GUILD_ID = "830522505605283862";
 }
 if (!QUOTE_ROLE_ID) {
-    console.warn(
+    logger.warn(
         "No 'quote_role_id' provided in .env file, using id of the SerenityOS reviewer role."
     );
 
     QUOTE_ROLE_ID = "830720377025986561";
+}
+
+if (!LOG_CHANNEL_ID) {
+    logger.warn(
+        "No 'log_channel_id' provided in .env file, useful debugging information might be lost!"
+    );
 }

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -14,6 +14,7 @@ export const GITHUB_TOKEN = process.env["github_token"];
 export let GUILD_ID = process.env["guild_id"];
 export let QUOTE_ROLE_ID = process.env["quote_role_id"];
 export const LOG_CHANNEL_ID = process.env["log_channel_id"];
+export let PRIVILEGED_GROUP_IDS = process.env["privileged_group_ids"]?.split?.(",") as string[];
 
 if (!DISCORD_TOKEN) {
     logger.error("No 'discord_token' provided in .env file.");
@@ -40,4 +41,9 @@ if (!LOG_CHANNEL_ID) {
     logger.warn(
         "No 'log_channel_id' provided in .env file, useful debugging information might be lost!"
     );
+}
+if (!PRIVILEGED_GROUP_IDS || PRIVILEGED_GROUP_IDS.length <= 0) {
+    logger.warn("No 'privileged_group_ids' provided in .env file, using the SerenityOS group ids.");
+
+    PRIVILEGED_GROUP_IDS = ["830720377025986561"];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,13 @@
  */
 
 import Discord, { Intents, Interaction } from "discord.js";
+
 import CommandHandler from "./commandHandler";
-import config from "./config/botConfig";
 import { DISCORD_TOKEN } from "./config/secrets";
+import config from "./config/botConfig";
+import logger from "./util/logger";
+
+logger.info("Starting BuggieBot!");
 
 process.on("unhandledRejection", reason => {
     console.log("Unhandled Rejection:", reason);
@@ -22,6 +26,7 @@ const client = new Discord.Client({
     partials: ["MESSAGE", "CHANNEL", "REACTION"],
 });
 
+logger.setClient(client).then(() => logger.start());
 const commandHandler = new CommandHandler(config.production);
 
 client.on("ready", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,12 @@ import Discord, { Intents, Interaction } from "discord.js";
 
 import CommandHandler from "./commandHandler";
 import { DISCORD_TOKEN } from "./config/secrets";
-import config from "./config/botConfig";
 import logger from "./util/logger";
 
 logger.info("Starting BuggieBot!");
 
 process.on("unhandledRejection", reason => {
-    console.log("Unhandled Rejection:", reason);
+    logger.info("Unhandled Rejection:", reason);
 });
 
 const client = new Discord.Client({
@@ -27,11 +26,11 @@ const client = new Discord.Client({
 });
 
 logger.setClient(client).then(() => logger.start());
-const commandHandler = new CommandHandler(config.production);
+const commandHandler = new CommandHandler();
 
 client.on("ready", () => {
     if (client.user != null) {
-        console.log(`Logged in as ${client.user.tag}.`);
+        logger.info(`Logged in as ${client.user.tag}. Took ${process.uptime()} seconds!`);
         client.user.setPresence({
             status: "online",
             activities: [
@@ -56,7 +55,7 @@ client.on("interactionCreate", async (interaction: Interaction) => {
     if (interaction.isSelectMenu()) commandHandler.handleSelectInteraction(interaction);
 });
 client.on("error", e => {
-    console.error("Discord client error!", e);
+    logger.error("Discord client error!", e);
 });
 client.on("messageCreate", async message => {
     if (message.author.bot) return;

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Client, ColorResolvable, MessageEmbed } from "discord.js";
+import { GUILD_ID, LOG_CHANNEL_ID } from "../config/secrets";
+
+import config from "../config/botConfig";
+import util from "node:util";
+
+export enum LogLevel {
+    Fatal = 0,
+    Trace,
+    Error,
+    Warn,
+    Info,
+    Verbose,
+    Debug,
+    Silly,
+}
+export class Logger {
+    // Handle pre-setup logs
+    private running = false;
+    private startupQueue: MessageEmbed[] = [];
+
+    private client?: Client;
+    private channel: any;
+
+    private _level: LogLevel = config.logLevel;
+    public get level() {
+        return this._level;
+    }
+
+    public async start() {
+        this.running = true;
+
+        // We're now up and running, let's emit the startup log.
+        // FIXME: Group them together (discord allows for up to 10
+        //        in one single message, it's a bit hit and miss
+        //        with our current discord.js version though).
+        await Promise.all(
+            this.startupQueue
+                .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
+                .map(async card => await this.emitToDiscord([card]))
+        );
+        this.startupQueue = [];
+    }
+
+    public fatal(...message: any) {
+        this.handleLogMessage(LogLevel.Fatal, ...message)
+            .then(() => process.exit(1))
+            .catch(e => {
+                console.trace(e);
+                process.exit(1);
+            });
+    }
+    public trace(...message: any) {
+        this.handleLogMessage(LogLevel.Trace, ...message);
+    }
+    public error(...message: any) {
+        this.handleLogMessage(LogLevel.Error, ...message);
+    }
+    public warn(...message: any) {
+        this.handleLogMessage(LogLevel.Warn, ...message);
+    }
+    public info(...message: any) {
+        this.handleLogMessage(LogLevel.Info, ...message);
+    }
+    public verbose(...message: any) {
+        this.handleLogMessage(LogLevel.Verbose, ...message);
+    }
+    public debug(...message: any) {
+        this.handleLogMessage(LogLevel.Debug, ...message);
+    }
+    public silly(...message: any) {
+        this.handleLogMessage(LogLevel.Silly, ...message);
+    }
+
+    public async setClient(client: Client) {
+        this.client = client;
+
+        if (!GUILD_ID || !LOG_CHANNEL_ID) return;
+        this.channel = await (
+            await this.client.guilds.fetch(GUILD_ID)
+        ).channels.fetch(LOG_CHANNEL_ID);
+    }
+
+    public setLevel(level: LogLevel) {
+        this._level = level;
+    }
+
+    public async clear(amount = 100) {
+        await this.channel.bulkDelete(amount);
+    }
+
+    public getLevelColor(level: LogLevel): ColorResolvable {
+        switch (level) {
+            case LogLevel.Fatal:
+            case LogLevel.Trace:
+            case LogLevel.Error:
+                return "#FF0000";
+            case LogLevel.Warn:
+                return "#FFFF00";
+            case LogLevel.Verbose:
+                return "#8AE234";
+            case LogLevel.Silly:
+                return "#800080";
+            default:
+                return "#729FCF";
+        }
+    }
+
+    private printToCorrectConsole(level: LogLevel, prefix: string, ...data: any[]) {
+        let consoleMethod = console.log;
+        switch (level) {
+            case LogLevel.Fatal: {
+                consoleMethod = console.debug;
+                break;
+            }
+            case LogLevel.Error: {
+                consoleMethod = console.error;
+                break;
+            }
+            case LogLevel.Warn: {
+                consoleMethod = console.warn;
+                break;
+            }
+            case LogLevel.Info: {
+                consoleMethod = console.info;
+                break;
+            }
+            case LogLevel.Trace:
+            case LogLevel.Debug: {
+                consoleMethod = console.debug;
+                break;
+            }
+            default:
+                consoleMethod = console.log;
+        }
+        consoleMethod(
+            prefix,
+            util
+                .formatWithOptions(
+                    {
+                        colors: true,
+                        breakLength: 60,
+                        compact: false,
+                    },
+                    "%o",
+                    ...data
+                )
+                .split("\n")
+                .join("\n".padEnd(4)) // Indent multiline-outputs
+        );
+    }
+
+    private async emitToDiscord(cards: MessageEmbed[]) {
+        await this.channel.send({
+            embeds: cards,
+        });
+    }
+
+    private async handleLogMessage(level: LogLevel, ...data: any[]) {
+        const caller = (data[0] instanceof Error ? data[0] : new Error(""))?.stack
+            ?.split("\n")[3]
+            .replace("    at ", "") as string;
+
+        let base = "";
+        if (caller?.includes("/build/")) base = "/build/";
+        else if (caller?.includes("/src/")) base = "/src/";
+
+        const file = caller?.split(base)[1].split(")")[0];
+        const line = file.split(":")[1];
+        const method = caller.split(" ")[0];
+
+        const msg = util.formatWithOptions(
+            {
+                colors: false,
+                breakLength: 60, // to fit inside a discord embed.
+                maxStringLength: 4000, // discord's max is 4096.
+            },
+            "%o",
+            ...data
+        );
+
+        this.printToCorrectConsole(
+            level,
+            `${LogLevel[level].toUpperCase()}${
+                this.level > LogLevel.Info ? ` [${file}]` : ""
+            } [${method}]:`,
+            ...data
+        );
+
+        if ((!this.channel && this.running) || level > this.level) return;
+
+        const card = new MessageEmbed()
+            .setColor(this.getLevelColor(level))
+            .setAuthor({
+                name: "BuggieBot",
+                iconURL: "https://github.com/BuggieBot.png",
+                url: "https://github.com/BuggieBot",
+            })
+            .setTitle(`${LogLevel[level].toUpperCase()} - SerenityOS/discord-bot`)
+            .setURL(`https://github.com/SerenityOS/discord-bot`)
+            .setDescription(`${"```javascript\n"}${msg}${"```"}`)
+            .addFields(
+                {
+                    name: "Method",
+                    value: method,
+                    inline: true,
+                },
+                {
+                    name: "Filename",
+                    value: `[${file}](https://github.com/SerenityOS/discord-bot/tree/master/src/${
+                        file.split(":")[0]
+                    }#L${line})`,
+                    inline: true,
+                }
+            )
+            .setTimestamp(Date.now());
+
+        if (!this.running) {
+            this.startupQueue.push(card);
+            return;
+        }
+
+        await this.emitToDiscord([card]);
+    }
+}
+
+const logger = new Logger();
+export default logger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,27 @@
     ts-mixer "^6.0.1"
     tslib "^2.4.0"
 
+"@discordjs/builders@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-1.3.0.tgz#20d4e3fbcd734ce2468df10407c7c6df22c9f77e"
+  integrity sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==
+  dependencies:
+    "@discordjs/util" "^0.1.0"
+    "@sapphire/shapeshift" "^3.7.0"
+    discord-api-types "^0.37.12"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.1"
+    tslib "^2.4.0"
+
 "@discordjs/collection@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.7.0.tgz#1a6c00198b744ba2b73a64442145da637ac073b8"
   integrity sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==
+
+"@discordjs/util@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/util/-/util-0.1.0.tgz#e42ca1bf407bc6d9adf252877d1b206e32ba369a"
+  integrity sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
@@ -262,6 +279,14 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-3.1.0.tgz#e4719fd03ab1d3ea01170f9c37b9cb64f5794759"
   integrity sha512-PkxFXd3QJ1qAPS05Dy2UkVGYPm/asF1Ugt2Xyzmv4DHzO3+G7l+873C4XFFcJ9M5Je+eCMC7SSifgPTSur5QuA==
+
+"@sapphire/shapeshift@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz#488cf06857be75826292dac451c13eeb0143602d"
+  integrity sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash.uniqwith "^4.5.0"
 
 "@sindresorhus/is@^4.6.0":
   version "4.6.0"
@@ -714,6 +739,11 @@ discord-api-types@^0.33.3:
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.33.5.tgz#6548b70520f7b944c60984dca4ab58654d664a12"
   integrity sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==
+
+discord-api-types@^0.37.12:
+  version "0.37.16"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.37.16.tgz#3cc5fb56d34d12f57f20f81708ac0963b24c3e96"
+  integrity sha512-H0FDY6+ww4YZe1+L+2ERWU3KsVSInWLvK0TeImhiTi49DXff8sFLnqqnEiEdMEhwFlkQMUIe4xL5Py046s+Ksg==
 
 discord.js@^13.8.1:
   version "13.8.1"
@@ -1214,6 +1244,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.uniqwith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
+  integrity sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==
 
 log-symbols@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
My goal with this PR is to make the debugging of `BuggieBot` a little bit more pleasant; and hopefully find a way to properly catch #533.

Configuration required:
  - `log_level`: number based on the `LogLevel` enum (optional, currently defaults to `Verbose`).
  - `log_channel_id`: the logger's output channel (technically optional, but no).
  - `privileged_group_ids`: comma separated list of group ids (optional, defaults to `100 Commit Club`)

A new logging channel should probably be configured in such a way that notifications are turned off by default as to not spam everybody.

![image](https://user-images.githubusercontent.com/108444335/200191244-7ddab2d5-2992-4522-82cd-1ec7e81c63a1.png)