### PR TITLE
ManCommand: Fix min/max actions

### DIFF
--- a/src/commands/manCommand.ts
+++ b/src/commands/manCommand.ts
@@ -90,9 +90,11 @@ export class ManCommand extends Command {
         if (message.embeds.length === 1) {
             const embed: MessageEmbed = message.embeds[0];
 
-            if (!embed.url) return;
+            if (!embed.description) return;
 
-            const result = await githubAPI.fetchSerenityManpageByUrl(embed.url);
+            const result = await githubAPI.fetchSerenityManpageByUrl(
+                embed.description?.match(/\(([^)]+)\)/)![1]
+            );
 
             if (result == null) return;
 


### PR DESCRIPTION
This regressed in 4b088e8 due to changing the embed's main URL from the GitHub one to the `man.serenity.org` one.

The solution was to instead use the GitHub link we have in the embed's description.