### PR TITLE
GithubCommand: Update channel / category mappings to match ladybird monorepo merge

### DIFF
--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -41,18 +41,6 @@ const repositories: Array<{
             "976984132376744027",
         ],
     },
-    {
-        name: "ladybird",
-        repository: {
-            owner: "SerenityOS",
-            name: "ladybird",
-        },
-        urlRegex: /.+github.com\/SerenityOS\/ladybird\/(?:issues|pull)\/(\d+).*/,
-        defaultChannels: [
-            // #browser-qt
-            "1022888574925947040",
-        ],
-    },
 ];
 
 export class GithubCommand extends Command {

--- a/src/commands/githubCommand.ts
+++ b/src/commands/githubCommand.ts
@@ -22,11 +22,14 @@ const repositories: Array<{
         repository: SERENITY_REPOSITORY,
         urlRegex: /.+github.com\/SerenityOS\/serenity\/(?:issues|pull)\/(\d+).*/,
         defaultCategories: [
-            // DEVELOPMENT
-            "830526756619288616",
-
             // SUPPORT
             "836187014617104394",
+
+            // LADYBIRD
+            "1027909057962573895",
+
+            // DEVELOPMENT
+            "830526756619288616",
         ],
     },
     {


### PR DESCRIPTION
This pull requests updates the mappings for `/github` and friends to not default to the archived ladybird repository.