### PR TITLE
Commands: Add testwasm command to print out LibWasm's spec test results 

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -24,5 +24,5 @@ export * from "./manCommand";
 export * from "./planCommand";
 export * from "./quickLinksCommand";
 export * from "./quoteCommand";
-export * from "./test262Command";
+export * from "./testCommand";
 export * from "./userCommand";

--- a/src/commands/testCommand.ts
+++ b/src/commands/testCommand.ts
@@ -51,6 +51,11 @@ const variants: Record<string, TestVariant> = {
         url: "https://libjs.dev/test262/data/results.json",
         nameForCommitError: "test262",
     },
+    testwasm: {
+        description: "Display Wasm spec test results",
+        url: "https://libjs.dev/wasm/data/results.json",
+        nameForCommitError: "Wasm spec tests",
+    },
 };
 
 export class TestCommand extends Command {


### PR DESCRIPTION
First factor out the common logic from the test262 command file, and move it into utils. Then we can build the testwasm command on top of that as they report results in the same format.

Fixes #844 

