### PR TITLE
Meta+Commands: Fix one minor and one major issue

### DIFF
--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -189,7 +189,14 @@ export default class CommandHandler {
     ): Promise<void> {
         return await handler.call(command, interaction).catch(error => {
             console.trace("matchedCommand.handle{Select|Context}Menu failed", error);
-            interaction.reply({ ephemeral: true, content: `Failed because of ${error}` });
+
+            const content = `⚠️ Something went extremely wrong!\n \`\`\`\n${
+                (error as any)?.stack ?? error ?? ""
+            }\n\`\`\``;
+            if ((interaction as any).deferred || (interaction as any).replied)
+                return (interaction as any).editReply({ content });
+
+            interaction.reply({ ephemeral: true, content });
         });
     }
 }

--- a/src/util/embedFromIssueOrPull.ts
+++ b/src/util/embedFromIssueOrPull.ts
@@ -165,8 +165,6 @@ export function embedFromPull(
             },
             {
                 name: "State",
-                // @ts-expect-error Intl.ListFormat is not yet part of the typescript library definitions,
-                //                  see https://github.com/microsoft/TypeScript/issues/46907
                 value: new Intl.ListFormat().format(state),
                 inline: true,
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ESNEXT",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2020"],                        /* Specify library files to be included in the compilation. */
+    "lib": ["ESNext"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
1. caef430c7f21d8d94c0efb292a04c48477eea3cb updates the lib version from `es2020` to `esnext` which means that it now matches the rest of the environment, it also means that we don't need that `@ts-expect-error` comment anymore.

2. 80a54bbbac345b8e51b3013df97d5586ddce5085 fixes the `handler.call` callback inside of the `commandHandler` to account for both **`deferred`** and **`replied`** interactions and use the correct `editReply`. Before this a fix we got no proper error output outside of the private (ssh?) terminal which isn't helpful for contributors like me who don't have access to it; so I fixed it.

:^)