### PR TITLE
Meta: Specify "--files" when running ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "lint": "eslint . --ext .ts",
         "lint-and-fix": "eslint . --ext .ts --fix",
-        "start:dev": "nodemon --watch './src/**' --ext 'ts,js,json' --exec \"ts-node ./src/index.ts\"",
+        "start:dev": "nodemon --watch './src/**' --ext 'ts,js,json' --exec \"ts-node --files ./src/index.ts\"",
         "prebuild": "rimraf ./build",
         "build": "tsc",
         "prestart": "npm run build",


### PR DESCRIPTION
We're setting "include" and "exclude" in our tsconfig, but ts-node will only load them if "--files" is passed to it.

This fixes up the "start:dev" command.