### PR TITLE
QuoteCommand: Getting it working again

### DIFF
--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -159,13 +159,10 @@ export class QuoteCommand extends Command {
             };
         }
 
-        const originalMessage = await interaction.channel?.messages.fetch(interaction.commandId);
-        if (!originalMessage) return;
-
         // Option 3b: The quote's message ID was given
         try {
-            const message = await originalMessage.channel.messages.fetch(argument);
-            if (message.guild == null) return;
+            const message = await interaction.channel?.messages.fetch(argument);
+            if (message?.guild == null) return;
             return {
                 guildId: message.guild.id,
                 channelId: message.channel.id,

--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -100,11 +100,16 @@ export class QuoteCommand extends Command {
         });
 
         const commandIssuerNick = await this.getAuthorNick(guild, interaction.user);
-        const pullRequestNumber = await githubAPI.openFortunesPullRequest(
-            fortunes,
-            commandIssuerNick,
-            nickname
-        );
+        let pullRequestNumber;
+        try {
+            pullRequestNumber = await githubAPI.openFortunesPullRequest(
+                fortunes,
+                commandIssuerNick,
+                nickname
+            );
+        } catch (e) {
+            console.trace(e);
+        }
 
         if (pullRequestNumber == undefined) {
             const sadcaret = await getSadCaret(interaction);

--- a/src/commands/quoteCommand.ts
+++ b/src/commands/quoteCommand.ts
@@ -24,7 +24,7 @@ import Command from "./command";
 
 export class QuoteCommand extends Command {
     private readonly messageLinkRegex: RegExp =
-        /https:\/\/(?:(?:ptb|canary)\.)?discord\.com\/channels\/(?<guild>[0-9]{17,18})\/(?<channel>[0-9]{17,18})\/(?<message>[0-9]{17,18})/;
+        /https:\/\/(?:(?:ptb|canary)\.)?discord\.com\/channels\/(?<guild>\d*)\/(?<channel>\d*)\/(?<message>\d*)$/;
 
     override data() {
         if (!QUOTE_ROLE_ID) return [];


### PR DESCRIPTION
With these patches, `/quote` seems to work again (on a testing repo of mine, [link](https://github.com/CommandMC/BuggieBot_Test/pull/1)).

I don't know the cause of #533 yet (an issue in the create-pull-request plugin repo points to missing authentication, [link](https://github.com/gr2m/octokit-plugin-create-pull-request/issues/20#issuecomment-532261923)). Could someone with access to the public bot confirm that our issue is still valid?